### PR TITLE
fix: test glob broken on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "node ./bin/www",
-    "test": "node --test test/**/*.test.js"
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "array-unique": "^0.3.2",


### PR DESCRIPTION
`test/**/*.test.js` is passed to `sh -c` by npm, and `sh` does not expand `**`. Node 20 received the literal string and could not find the file.

Changed to `test/*.test.js` - all test files are flat in `test/`, so `*` is enough and expands in any POSIX shell.

Reproduces on Node 20 only; Node 22+ was more forgiving in CI.