### PR TITLE
test: add 10 tests

### DIFF
--- a/test/apiUrl.test.js
+++ b/test/apiUrl.test.js
@@ -17,3 +17,18 @@ test('getPathUrl includes route code in query string', () => {
     const url = apiUrl.getPathUrl('5');
     assert.ok(url.includes('code=5'), `got: ${url}`);
 });
+
+test('getBusUrl returns a string', () => {
+    const url = apiUrl.getBusUrl();
+    assert.equal(typeof url, 'string');
+});
+
+test('getRouteUrl includes RouteMonitoring path segment', () => {
+    const url = apiUrl.getRouteUrl('10');
+    assert.ok(url.includes('RouteMonitoring'), `got: ${url}`);
+});
+
+test('getPathUrl includes path/ segment', () => {
+    const url = apiUrl.getPathUrl('3');
+    assert.ok(url.includes('path/'), `got: ${url}`);
+});

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,28 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('defaultUpdate is a finite number', () => {
+    const config = require('../config/index');
+    assert.equal(typeof config.defaultUpdate, 'number');
+    assert.ok(Number.isFinite(config.defaultUpdate), `expected finite number, got: ${config.defaultUpdate}`);
+});
+
+test('defaultUpdate defaults to 5000 when DEFAULT_UPDATE env var is absent', () => {
+    const saved = process.env.DEFAULT_UPDATE;
+    delete process.env.DEFAULT_UPDATE;
+
+    const configPath = require.resolve('../config/index');
+    delete require.cache[configPath];
+    const freshConfig = require('../config/index');
+
+    assert.equal(freshConfig.defaultUpdate, 5000);
+
+    // restore env and evict the fresh module so later tests see original state
+    if (saved !== undefined) process.env.DEFAULT_UPDATE = saved;
+    delete require.cache[configPath];
+});
+
+test('apiUrl is a string', () => {
+    const config = require('../config/index');
+    assert.equal(typeof config.apiUrl, 'string');
+});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -33,3 +33,14 @@ test('getRoutes rejects with status code when server returns error', async () =>
         (err) => err.code === 503
     );
 });
+
+test('getPathData calls an endpoint that includes path/', async () => {
+    const res = await model.getPathData('7');
+    assert.ok(capturedUrl.includes('path/'), `URL was: ${capturedUrl}`);
+    assert.equal(res.getBody(), '[{"id":1}]');
+});
+
+test('getRoutes resolves and getBody() returns the mocked text', async () => {
+    const res = await model.getRoutes('15');
+    assert.equal(res.getBody(), '[{"id":1}]');
+});

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,0 +1,15 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+test('routes module loads without throwing', () => {
+    assert.doesNotThrow(() => require('../routes/index'));
+});
+
+test('/json route is registered on the router', () => {
+    const router = require('../routes/index');
+    // Express router exposes its registered layers via .stack
+    const paths = router.stack
+        .filter(layer => layer.route)
+        .map(layer => layer.route.path);
+    assert.ok(paths.includes('/json'), `registered paths: ${paths.join(', ')}`);
+});


### PR DESCRIPTION
## Summary

- Expands test suite from 6 to 16 tests (10 new tests added)
- New `test/config.test.js`: verifies `defaultUpdate` is a finite number, defaults to 5000 when `DEFAULT_UPDATE` env var is absent, and `apiUrl` is a string
- New `test/routes.test.js`: verifies the routes module loads without error and the `/json` route is registered on the router
- Extended `test/apiUrl.test.js`: `getBusUrl` returns a string, `getRouteUrl` includes `RouteMonitoring`, `getPathUrl` includes `path/`
- Extended `test/model.test.js`: `getPathData` hits the `path/` endpoint, `getRoutes` resolves with the mocked body text

## Test plan

- [x] `node --test test/*.test.js` runs 16 tests, all pass, 0 failures
- [x] Uses only built-in `node:test` and `node:assert/strict`, zero new dependencies
- [x] Each test is self-contained and cleans up any global/env state it mutates