### PR TITLE
feat: config validation - warn on missing API_URL

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -5,6 +5,7 @@
  */
 
 var app = require('../app');
+var config = require('../config');
 var debug = require('debug')('express.js:server');
 var http = require('http');
 
@@ -12,7 +13,7 @@ var http = require('http');
  * Get port from environment and store in Express.
  */
 
-var port = normalizePort(process.env.PORT || '3000');
+var port = normalizePort(config.port);
 app.set('port', port);
 
 /**

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,13 @@
 require('dotenv').config();
 
+if (!process.env.API_URL && process.env.NODE_ENV !== 'test') {
+    console.warn('[config] WARNING: API_URL is not set - API requests will fail. Copy .env.example to .env');
+}
+
+const parsedUpdate = parseInt(process.env.DEFAULT_UPDATE);
+
 module.exports = {
     apiUrl: process.env.API_URL || '',
-    defaultUpdate: parseInt(process.env.DEFAULT_UPDATE) || 5000,
+    defaultUpdate: (parsedUpdate > 0) ? parsedUpdate : 5000,
+    port: parseInt(process.env.PORT) || 3000,
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "start": "node ./bin/www",
-    "test": "node --test test/*.test.js"
+    "test": "NODE_ENV=test node --test test/*.test.js"
   },
   "dependencies": {
     "cookie-parser": "^1.4.7",


### PR DESCRIPTION
## Summary

- Warn at startup if `API_URL` is not set (suppressed in test env via `NODE_ENV=test`)
- Add `PORT` to config exports; `bin/www` now reads `config.port` instead of `process.env.PORT` directly
- Validate `DEFAULT_UPDATE` is a positive number; falls back to `5000` if `NaN` or `<= 0`

## Test plan

- [ ] `npm test` passes (all 6 tests green, warning suppressed by `NODE_ENV=test`)
- [ ] Starting the app without `.env` prints `[config] WARNING: API_URL is not set - API requests will fail. Copy .env.example to .env`
- [ ] Starting with a valid `.env` (API_URL set) produces no warning
- [ ] `DEFAULT_UPDATE=0` or `DEFAULT_UPDATE=abc` falls back to `5000`