### PR TITLE
fix: frontend behavioral bugs in map/events JS

### DIFF
--- a/public/js/events.js
+++ b/public/js/events.js
@@ -60,7 +60,7 @@ var drawRoute = function (data) {
 var eventRemoveRoute = function (code_route) {
 
     mapUtil.removePath(code_route);
-    mapUtil.deleteMarkers();
+    mapUtil.deleteMarkersByCode(code_route);
 
 };
 

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -161,21 +161,20 @@ function MapUtil(map) {
     };
 
     this.removePath = function (code) {
-        var mapPath = paths[code] || 0;
+        var mapPath = paths[code];
+        if (!mapPath) return;
         mapPath.setMap(null);
+        delete paths[code];
     };
 
     this.deleteMarkersByCode = function (code) {
-        for (var i = 0; i < markers.length; i++) {
-            var marker = markers[i];
-            var marker_code = marker.routeCode;
-            console.log(marker_code);
-            console.log(code);
-            if (marker_code == code) {
+        markers = markers.filter(function (marker) {
+            if (marker.routeCode == code) {
                 marker.setMap(null);
-                markers.splice(i, 1);
+                return false;
             }
-        }
+            return true;
+        });
     };
 
 }

--- a/public/js/markerAnimate.js
+++ b/public/js/markerAnimate.js
@@ -10,7 +10,7 @@
 // options.complete   - callback function. Gets called, after the animation has finished
 
 google.maps.Marker.prototype.animateTo = function (newPosition, options) {
-    defaultOptions = {
+    var defaultOptions = {
         duration: 1000,
         easing: 'linear',
         complete: null
@@ -18,7 +18,7 @@ google.maps.Marker.prototype.animateTo = function (newPosition, options) {
     options = options || {};
 
     // complete missing options
-    for (key in defaultOptions) {
+    for (var key in defaultOptions) {
         options[key] = options[key] || defaultOptions[key];
     }
 
@@ -26,7 +26,6 @@ google.maps.Marker.prototype.animateTo = function (newPosition, options) {
     if (options.easing != 'linear') {
         if (typeof jQuery == 'undefined' || !jQuery.easing[options.easing]) {
             throw '"' + options.easing + '" easing function doesn\'t exist. Include jQuery and/or the jQuery easing plugin and use the right function name.';
-            return;
         }
     }
 


### PR DESCRIPTION
- fix: eventRemoveRoute called deleteMarkers() (all routes) - now calls deleteMarkersByCode(code)
- fix: removePath crashed with TypeError when code not in paths (|| 0 fallback)
- fix: deleteMarkersByCode splice-in-loop skipped consecutive markers - now uses filter
- fix: markerAnimate.js implicit globals (defaultOptions, key) - added var declarations
- fix: remove unreachable return after throw in markerAnimate.js