### PR TITLE
fix: Google Maps key to env var, restrict node_modules serving

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 PORT=3000
 API_URL=http://your-api-host/api/
 DEFAULT_UPDATE=5000
+# Google Maps JavaScript API key (restrict by HTTP referrer in Google Cloud Console)
+GOOGLE_MAPS_KEY=

--- a/app.js
+++ b/app.js
@@ -24,8 +24,8 @@ app.use(express.urlencoded({extended: false}));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
-// node_modules
-app.use('/scripts', express.static(path.join(__dirname, 'node_modules')));
+// node_modules - serve only the hammerjs package, not all of node_modules
+app.use('/scripts/hammerjs', express.static(path.join(__dirname, 'node_modules', 'hammerjs')));
 
 //define routes
 app.use('/', router);

--- a/config/index.js
+++ b/config/index.js
@@ -10,4 +10,5 @@ module.exports = {
     apiUrl: process.env.API_URL || '',
     defaultUpdate: (parsedUpdate > 0) ? parsedUpdate : 5000,
     port: parseInt(process.env.PORT) || 3000,
+    googleMapsKey: process.env.GOOGLE_MAPS_KEY || '',
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,15 +2,16 @@ const express = require('express');
 const router = express.Router();
 
 const model = require('../models/model');
+const config = require('../config');
 
 /* about page. */
 router.get('/about', function (req, res, next) {
-    res.render('pages/about', { title: 'About' });
+    res.render('pages/about', { title: 'About', googleMapsKey: config.googleMapsKey });
 });
 
 /* GET home page. */
 router.get('/', async function (req, res, next) {
-    const view_data = {title: 'LvivTransportMonitoringExpress'};
+    const view_data = {title: 'LvivTransportMonitoringExpress', googleMapsKey: config.googleMapsKey};
 
     try {
         const response = await model.getBuses();

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -11,7 +11,7 @@
 
 <script src="/js/map.js"></script>
 <script
-        src="//maps.googleapis.com/maps/api/js?key=AIzaSyAvrMVU3uFdYFA3sefM07w3ZB7l_GlBKcM&callback=initMap"></script>
+        src="//maps.googleapis.com/maps/api/js?key=<%= googleMapsKey %>&callback=initMap"></script>
 <script src="/js/markerAnimate.js"></script>
 
 <script src="/js/events.js"></script>


### PR DESCRIPTION
- fix: Google Maps API key moved from hardcoded footer.ejs to GOOGLE_MAPS_KEY env var
- fix: node_modules no longer fully public over HTTP - only /scripts/hammerjs served
- Add GOOGLE_MAPS_KEY to .env.example

Note: The hardcoded key AIzaSyAvrMVU3uFdYFA3sefM07w3ZB7l_GlBKcM is in git history - rotate it in Google Cloud Console and restrict by HTTP referrer.