### PR TITLE
feat: migrate from dead SimpleRIDE API to live api.lad.lviv.ua

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,4 @@
 PORT=3000
-API_URL=http://your-api-host/api/
 DEFAULT_UPDATE=5000
 # Google Maps JavaScript API key (restrict by HTTP referrer in Google Cloud Console)
 GOOGLE_MAPS_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ npm-debug.log*
 
 .idea/
 .DS_Store
+
+.claude/

--- a/README.md
+++ b/README.md
@@ -4,18 +4,20 @@
 
 Real-time public transit tracker for Lviv, Ukraine. Select bus routes on a Google Map and watch vehicle positions update live every 5 seconds.
 
-> **Note:** This is a demo project built in 2017. The SimpleRIDE API provided by the Lviv transit authority may no longer be publicly accessible. The code and architecture remain a working example of real-time Socket.IO polling, but live data cannot be guaranteed.
-
 ![preview](docs/preview.gif)
+
+## History
+
+Built in 2017 against the SimpleRIDE API provided by the Lviv transit authority. That API went offline in July 2018 and stayed dead for years. In 2026 the project was modernized (Node 24, Express 5, Socket.IO 4) and migrated to [api.lad.lviv.ua](https://github.com/vbhjckfd/timetable-api-node) - an open, live JSON REST API for Lviv public transit. Live bus data works again.
 
 ## How it works
 
-The server fetches available bus routes from the SimpleRIDE API on startup. When a user checks a route in the sidebar, the browser emits a Socket.IO event, the server draws the route path on the map and begins polling live vehicle positions every 5 seconds, pushing updates back to all subscribed clients. Markers animate smoothly as positions change. On mobile, the route sidebar supports swipe gestures via HammerJS.
+The server fetches available bus routes from `api.lad.lviv.ua` on page load. When a user checks a route in the sidebar, the browser emits a Socket.IO event; the server draws the route path on the map and begins polling live vehicle positions every 5 seconds, pushing updates back to all subscribed clients. Markers animate smoothly as positions change. On mobile, the route sidebar supports swipe gestures via HammerJS.
 
 ```
 Browser ──(checkbox toggle)──> socket.emit('add-bus', routeCode)
-Server ──> fetch SimpleRIDE API for route path ──> socket.emit('drawRoute', data)
-Server setInterval(5s) ──> fetch live positions ──> socket.emit('defaultUpdate', data, code)
+Server ──> GET /routes/static/:name ──> socket.emit('drawRoute', path)
+Server setInterval(5s) ──> GET /routes/dynamic/:name ──> socket.emit('defaultUpdate', vehicles, code)
 Browser ──> animate markers on Google Map
 ```
 
@@ -29,31 +31,22 @@ Browser ──> animate markers on Google Map
 - HammerJS 2 (mobile swipe gestures)
 - Bootstrap 3
 
-## Requirements
-
-- Node.js 20+
-- A Google Maps API key with the Maps JavaScript API enabled
-- Access to a SimpleRIDE API endpoint (Lviv transit authority; may be unavailable - see note above)
-
 ## Setup
 
 ```bash
 git clone https://github.com/tegos/lviv-transit-tracker.git
 cd lviv-transit-tracker
 npm install
-```
-
-Copy `.env.example` to `.env` and fill in your values:
-
-```bash
 cp .env.example .env
 ```
 
+Edit `.env` and set your Google Maps key:
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PORT` | `3000` | HTTP port the server listens on |
-| `API_URL` | - | Base URL of the SimpleRIDE Web API |
+| `PORT` | `3000` | HTTP port |
 | `DEFAULT_UPDATE` | `5000` | Polling interval in milliseconds |
+| `GOOGLE_MAPS_KEY` | - | Google Maps JavaScript API key |
 
 ## Start
 
@@ -61,18 +54,19 @@ cp .env.example .env
 npm start
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in a browser. Check any route in the sidebar to start tracking it on the map.
+Open [http://localhost:3000](http://localhost:3000). Check any route in the sidebar to track it on the map.
 
 ## Project structure
 
 ```
-app.js          - Express app, Socket.IO event handlers, polling interval
-bin/www         - HTTP server entry point
-routes/         - Express route definitions
-models/         - SimpleRIDE API client
+app.js          - Express app entry
+bin/www         - HTTP server
+routes/         - Express route handlers
+models/         - API client (fetch wrapper)
+socket/         - Socket.IO event handlers and polling loop
 views/          - EJS templates
 public/         - Static assets (JS, CSS)
-utils/          - Shared utilities
+utils/          - URL builders
 test/           - Node built-in test runner specs
 ```
 
@@ -84,7 +78,7 @@ npm test
 
 ## Contributing
 
-1. Fork the repo and create a feature branch (`git checkout -b my-feature`)
+1. Fork the repo and create a feature branch (`git checkout -b feat/my-feature`)
 2. Make your changes and add tests where relevant
 3. Push the branch and open a pull request
 

--- a/config/index.js
+++ b/config/index.js
@@ -1,13 +1,8 @@
 require('dotenv').config();
 
-if (!process.env.API_URL && process.env.NODE_ENV !== 'test') {
-    console.warn('[config] WARNING: API_URL is not set - API requests will fail. Copy .env.example to .env');
-}
-
 const parsedUpdate = parseInt(process.env.DEFAULT_UPDATE);
 
 module.exports = {
-    apiUrl: process.env.API_URL || '',
     defaultUpdate: (parsedUpdate > 0) ? parsedUpdate : 5000,
     port: parseInt(process.env.PORT) || 3000,
     googleMapsKey: process.env.GOOGLE_MAPS_KEY || '',

--- a/routes/index.js
+++ b/routes/index.js
@@ -16,15 +16,17 @@ router.get('/', async function (req, res, next) {
     try {
         const response = await model.getBuses();
         const content = response.getBody();
-        const stops = JSON.parse(content);
+        const routes = JSON.parse(content);
 
-        stops.forEach(function (stop, key) {
-            const words = stop['Name'].split(" ");
-            stop['SmallName'] = words[0];
-            stops[key] = stop;
+        routes.forEach(function (route, key) {
+            route['Name'] = route['long_name'];
+            route['SmallName'] = route['short_name'];
+            route['Code'] = route['short_name'];
+            route['Id'] = route['external_id'];
+            routes[key] = route;
         });
 
-        view_data.stops = stops;
+        view_data.stops = routes;
 
         return res.render('pages/index', view_data);
     } catch (error) {

--- a/socket/index.js
+++ b/socket/index.js
@@ -22,7 +22,9 @@ function setupSocket(io) {
 			Model.getPathData(route_id).then(function (response) {
 				const content = response.getBody();
 				const routePathData = JSON.parse(content);
-				const data = {path: routePathData, code: route_id};
+				const firstShape = routePathData.shapes[0] || [];
+				const path = firstShape.map(([lat, lng]) => ({ Y: lat, X: lng }));
+				const data = {path, code: route_id};
 				const sock = io.sockets.sockets.get(socket.id);
 				if (sock) sock.emit('drawRoute', data);
 			}).catch(function (err) {
@@ -51,7 +53,15 @@ function setupSocket(io) {
 		allBuses.forEach(function (route_code) {
 			Model.getRoutes(route_code).then(function (response) {
 				const content = response.getBody();
-				const routeData = JSON.parse(content);
+				const rawData = JSON.parse(content);
+				const routeData = rawData.map(v => ({
+					VehicleId: v.id,
+					X: v.location[1],
+					Y: v.location[0],
+					Angle: v.bearing,
+					RouteName: route_code,
+					VehicleName: v.id,
+				}));
 
 				for (const socket_id in socketDataClients) {
 					const array_buses = socketDataClients[socket_id];

--- a/test/apiUrl.test.js
+++ b/test/apiUrl.test.js
@@ -3,19 +3,10 @@ const assert = require('node:assert/strict');
 
 const apiUrl = require('../utils/apiUrl');
 
-test('getBusUrl returns CompositeRoute endpoint', () => {
+test('getBusUrl returns lad.lviv.ua routes.json endpoint', () => {
     const url = apiUrl.getBusUrl();
-    assert.ok(url.endsWith('CompositeRoute/'), `got: ${url}`);
-});
-
-test('getRouteUrl includes route code in query string', () => {
-    const url = apiUrl.getRouteUrl('27');
-    assert.ok(url.includes('code=27'), `got: ${url}`);
-});
-
-test('getPathUrl includes route code in query string', () => {
-    const url = apiUrl.getPathUrl('5');
-    assert.ok(url.includes('code=5'), `got: ${url}`);
+    assert.ok(url.includes('api.lad.lviv.ua'), `got: ${url}`);
+    assert.ok(url.endsWith('/routes.json'), `got: ${url}`);
 });
 
 test('getBusUrl returns a string', () => {
@@ -23,12 +14,26 @@ test('getBusUrl returns a string', () => {
     assert.equal(typeof url, 'string');
 });
 
-test('getRouteUrl includes RouteMonitoring path segment', () => {
-    const url = apiUrl.getRouteUrl('10');
-    assert.ok(url.includes('RouteMonitoring'), `got: ${url}`);
+test('getRouteUrl builds dynamic route URL with name', () => {
+    const url = apiUrl.getRouteUrl('27T');
+    assert.ok(url.includes('api.lad.lviv.ua'), `got: ${url}`);
+    assert.ok(url.includes('/routes/dynamic/27T'), `got: ${url}`);
 });
 
-test('getPathUrl includes path/ segment', () => {
-    const url = apiUrl.getPathUrl('3');
-    assert.ok(url.includes('path/'), `got: ${url}`);
+test('getRouteUrl URL-encodes non-ASCII route names', () => {
+    const url = apiUrl.getRouteUrl('А01');
+    assert.ok(url.includes('/routes/dynamic/'), `got: ${url}`);
+    assert.ok(!url.includes(' '), `URL must not contain spaces: ${url}`);
+});
+
+test('getPathUrl builds static route URL with name', () => {
+    const url = apiUrl.getPathUrl('5');
+    assert.ok(url.includes('api.lad.lviv.ua'), `got: ${url}`);
+    assert.ok(url.includes('/routes/static/5'), `got: ${url}`);
+});
+
+test('getPathUrl URL-encodes non-ASCII route names', () => {
+    const url = apiUrl.getPathUrl('А01');
+    assert.ok(url.includes('/routes/static/'), `got: ${url}`);
+    assert.ok(!url.includes(' '), `URL must not contain spaces: ${url}`);
 });

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -22,7 +22,3 @@ test('defaultUpdate defaults to 5000 when DEFAULT_UPDATE env var is absent', () 
     delete require.cache[configPath];
 });
 
-test('apiUrl is a string', () => {
-    const config = require('../config/index');
-    assert.equal(typeof config.apiUrl, 'string');
-});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -22,7 +22,7 @@ afterEach(() => {
 
 test('getBuses calls the bus endpoint and exposes body via getBody()', async () => {
     const res = await model.getBuses();
-    assert.ok(capturedUrl.includes('CompositeRoute'), `URL was: ${capturedUrl}`);
+    assert.ok(capturedUrl.includes('routes.json'), `URL was: ${capturedUrl}`);
     assert.equal(res.getBody(), '[{"id":1}]');
 });
 
@@ -34,9 +34,9 @@ test('getRoutes rejects with status code when server returns error', async () =>
     );
 });
 
-test('getPathData calls an endpoint that includes path/', async () => {
+test('getPathData calls the static route endpoint', async () => {
     const res = await model.getPathData('7');
-    assert.ok(capturedUrl.includes('path/'), `URL was: ${capturedUrl}`);
+    assert.ok(capturedUrl.includes('/routes/static/'), `URL was: ${capturedUrl}`);
     assert.equal(res.getBody(), '[{"id":1}]');
 });
 

--- a/utils/apiUrl.js
+++ b/utils/apiUrl.js
@@ -1,19 +1,9 @@
-var config = require('../config');
+const BASE_URL = 'https://api.lad.lviv.ua';
 
-var SimpleRIDE_URL = config.apiUrl;
-
-var apiUrl = {
-    getBusUrl: function () {
-        var url = SimpleRIDE_URL + 'CompositeRoute/';
-        return url;
-    },
-    getRouteUrl: function (code) {
-        return SimpleRIDE_URL + 'RouteMonitoring/?code=' + code;
-    },
-    getPathUrl: function (code) {
-        return SimpleRIDE_URL + 'path/?code=' + code;
-    }
+const apiUrl = {
+    getBusUrl: () => `${BASE_URL}/routes.json`,
+    getRouteUrl: (name) => `${BASE_URL}/routes/dynamic/${encodeURIComponent(name)}`,
+    getPathUrl: (name) => `${BASE_URL}/routes/static/${encodeURIComponent(name)}`
 };
-
 
 module.exports = apiUrl;


### PR DESCRIPTION
## Summary

- Replace all SimpleRIDE endpoints (offline since July 2018) with `api.lad.lviv.ua` - an open JSON REST API for Lviv public transit
- Transform response shapes in `socket/index.js` so the frontend receives the same data contract without touching `public/js/events.js`
- Remove `API_URL` env var (no longer needed - URLs are now hardcoded to the new base)
- Update README with migration history

## Changes

| File | What changed |
|---|---|
| `utils/apiUrl.js` | New endpoints: `/routes.json`, `/routes/dynamic/:name`, `/routes/static/:name` |
| `routes/index.js` | Map `long_name`/`short_name`/`external_id` to `Name`/`SmallName`/`Code`/`Id` for the template |
| `socket/index.js` | Reshape dynamic (vehicle positions) and static (path geometry) responses to frontend-expected format |
| `config/index.js` | Remove unused `API_URL` export and its startup warning |
| `.env.example` | Remove `API_URL` |
| `test/` | Update URL assertions to match new endpoints |
| `README.md` | History section, updated architecture diagram and env var table |

## Test plan

- [x] `npm test` - 15/15 pass
- [x] Server starts and `/json` returns live route data from `api.lad.lviv.ua`
- [x] Main page renders route list with Cyrillic route names
- [x] Checking a route draws the path on the map and shows live vehicle markers