### PR TITLE
refactor: professionalize socket protocol (namespaced events, camelCase payloads, event enum)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 PORT=3000
-DEFAULT_UPDATE=5000
+POLL_INTERVAL_MS=5000
 # Google Maps JavaScript API key (restrict by HTTP referrer in Google Cloud Console)
 GOOGLE_MAPS_KEY=

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Built in 2017 against the SimpleRIDE API provided by the Lviv transit authority.
 The server fetches available bus routes from `api.lad.lviv.ua` on page load. When a user checks a route in the sidebar, the browser emits a Socket.IO event; the server draws the route path on the map and begins polling live vehicle positions every 5 seconds, pushing updates back to all subscribed clients. Markers animate smoothly as positions change. On mobile, the route sidebar supports swipe gestures via HammerJS.
 
 ```
-Browser ──(checkbox toggle)──> socket.emit('add-bus', routeCode)
-Server ──> GET /routes/static/:name ──> socket.emit('drawRoute', path)
-Server setInterval(5s) ──> GET /routes/dynamic/:name ──> socket.emit('defaultUpdate', vehicles, code)
+Browser ──(checkbox toggle)──> socket.emit('route:subscribe', routeCode)
+Server ──> GET /routes/static/:name ──> socket.emit('route:path', { routeCode, path })
+Server setInterval(5s) ──> GET /routes/dynamic/:name ──> socket.emit('vehicles:update', vehicles, routeCode)
 Browser ──> animate markers on Google Map
 ```
 
@@ -27,9 +27,10 @@ Browser ──> animate markers on Google Map
 - Socket.IO 4 (server + client)
 - EJS 6 templates
 - dotenv (environment config)
+- Vite (frontend bundling; vanilla ES modules, no jQuery)
 - Google Maps JavaScript API
-- HammerJS 2 (mobile swipe gestures)
-- Bootstrap 3
+- HammerJS 2 (mobile swipe gestures, bundled)
+- Bootstrap 3 (CSS only)
 
 ## Setup
 
@@ -45,7 +46,7 @@ Edit `.env` and set your Google Maps key:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PORT` | `3000` | HTTP port |
-| `DEFAULT_UPDATE` | `5000` | Polling interval in milliseconds |
+| `POLL_INTERVAL_MS` | `5000` | Vehicle-position polling interval in milliseconds |
 | `GOOGLE_MAPS_KEY` | - | Google Maps JavaScript API key |
 
 ## Start
@@ -54,7 +55,7 @@ Edit `.env` and set your Google Maps key:
 npm start
 ```
 
-Open [http://localhost:3000](http://localhost:3000). Check any route in the sidebar to track it on the map.
+`npm start` runs the Vite build first (`prestart`), then boots the server. Open [http://localhost:3000](http://localhost:3000). Check any route in the sidebar to track it on the map.
 
 ## Project structure
 
@@ -63,17 +64,21 @@ app.js          - Express app entry
 bin/www         - HTTP server
 routes/         - Express route handlers
 models/         - API client (fetch wrapper)
-socket/         - Socket.IO event handlers and polling loop
+socket/         - Socket.IO event handlers, polling loop, event-name enum
+src/            - Frontend ES modules (bundled by Vite into public/dist)
 views/          - EJS templates
-public/         - Static assets (JS, CSS)
-utils/          - URL builders
+public/         - Static assets (CSS); public/dist holds the built bundle
+utils/          - URL builders, route-list cache
 test/           - Node built-in test runner specs
+e2e/            - Playwright browser smoke tests
 ```
 
 ## Running tests
 
 ```bash
-npm test
+npm test              # unit + socket integration (offline)
+INTEGRATION=1 npm test # also hit the live api.lad.lviv.ua
+npm run test:e2e      # Playwright browser smoke tests
 ```
 
 ## Contributing

--- a/config/index.js
+++ b/config/index.js
@@ -1,9 +1,9 @@
 require('dotenv').config();
 
-const parsedUpdate = parseInt(process.env.DEFAULT_UPDATE);
+const parsedPollInterval = parseInt(process.env.POLL_INTERVAL_MS);
 
 module.exports = {
-    defaultUpdate: (parsedUpdate > 0) ? parsedUpdate : 5000,
+    pollIntervalMs: (parsedPollInterval > 0) ? parsedPollInterval : 5000,
     port: parseInt(process.env.PORT) || 3000,
     googleMapsKey: process.env.GOOGLE_MAPS_KEY || '',
 };

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -19,7 +19,7 @@ test('home page renders routes from the bundle with no console errors', async ({
     expect(errors, `console errors: ${errors.join('\n')}`).toEqual([]);
 });
 
-test('toggling a route emits add-bus and the bundle handles the ack', async ({ page }) => {
+test('toggling a route subscribes and the bundle handles the ack', async ({ page }) => {
     await page.goto('/');
     // Wait for the bundle to finish loading the Maps API + initMap.
     await page.waitForFunction(() => !!(window.google && window.google.maps), null, { timeout: 20000 });

--- a/socket/events.js
+++ b/socket/events.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// Socket.IO event names, shared by the server (socket/index.js) and the
+// bundled client (src/). Single source of truth so the wire protocol can't
+// drift between the two sides.
+const SocketEvents = Object.freeze({
+    // client -> server
+    ROUTE_SUBSCRIBE: 'route:subscribe',
+    ROUTE_UNSUBSCRIBE: 'route:unsubscribe',
+    // server -> client
+    ROUTE_PATH: 'route:path',
+    VEHICLES_UPDATE: 'vehicles:update',
+});
+
+module.exports = SocketEvents;

--- a/socket/index.js
+++ b/socket/index.js
@@ -4,63 +4,63 @@ const Model = require('../models/model');
 const config = require('../config');
 const createRegistry = require('./clientRegistry');
 const { toVehicles, toPath, isValidRouteId } = require('./transform');
+const Events = require('./events');
 
 function setupSocket(io) {
 	const registry = createRegistry();
 
 	io.on('connection', function (socket) {
-		// add bus
-		socket.on('add-bus', async function (route_id, ack) {
-			if (!isValidRouteId(route_id)) {
-				if (typeof ack === 'function') ack({ ok: false, error: 'invalid route id' });
+		// subscribe to a route: send its path once, then stream vehicle updates
+		socket.on(Events.ROUTE_SUBSCRIBE, async function (routeCode, ack) {
+			if (!isValidRouteId(routeCode)) {
+				if (typeof ack === 'function') ack({ ok: false, error: 'invalid route code' });
 				return;
 			}
-			registry.add(socket.id, route_id);
+			registry.add(socket.id, routeCode);
 
 			try {
-				const response = await Model.getPathData(route_id);
+				const response = await Model.getPathData(routeCode);
 				const routePathData = JSON.parse(response.getBody());
 				const path = toPath(routePathData.shapes);
-				socket.emit('drawRoute', { path, code: route_id });
+				socket.emit(Events.ROUTE_PATH, { routeCode, path });
 				if (typeof ack === 'function') ack({ ok: true });
 			} catch (err) {
-				console.error('add-bus error:', err);
+				console.error(`${Events.ROUTE_SUBSCRIBE} error:`, err);
 				if (typeof ack === 'function') ack({ ok: false, error: err.message });
 			}
 		});
 
-		// remove bus
-		socket.on('remove-bus', function (route_id) {
-			registry.remove(socket.id, route_id);
+		// unsubscribe from a route
+		socket.on(Events.ROUTE_UNSUBSCRIBE, function (routeCode) {
+			registry.remove(socket.id, routeCode);
 		});
 
-		// disconnect
 		socket.on('disconnect', function () {
 			registry.disconnect(socket.id);
 		});
 	});
 
-	// poll active routes and push updates to their subscribers
-	const intervalDefaultUpdate = setInterval(async function () {
-		const routes = registry.activeRoutes();
-		if (routes.size === 0) return;
+	// poll active routes and push vehicle updates to their subscribers
+	const pollInterval = setInterval(async function () {
+		const routeCodes = registry.activeRoutes();
+		if (routeCodes.size === 0) return;
 
-		for (const route_code of routes) {
+		for (const routeCode of routeCodes) {
 			try {
-				const response = await Model.getRoutes(route_code);
+				const response = await Model.getRoutes(routeCode);
 				const rawData = JSON.parse(response.getBody());
-				const routeData = toVehicles(rawData, route_code);
+				const vehicles = toVehicles(rawData, routeCode);
 
-				for (const socket_id of registry.subscribersOf(route_code)) {
-					io.sockets.sockets.get(socket_id)?.emit('defaultUpdate', routeData, route_code);
+				for (const socketId of registry.subscribersOf(routeCode)) {
+					io.sockets.sockets.get(socketId)?.emit(Events.VEHICLES_UPDATE, vehicles, routeCode);
 				}
 			} catch (err) {
-				console.error('defaultUpdate error for route', route_code, ':', err);
+				console.error(`${Events.VEHICLES_UPDATE} error for route`, routeCode, ':', err);
 			}
 		}
-	}, config.defaultUpdate).unref();
+	}, config.pollIntervalMs).unref();
 
-	return intervalDefaultUpdate;
+	return pollInterval;
 }
 
 module.exports = setupSocket;

--- a/socket/transform.js
+++ b/socket/transform.js
@@ -5,19 +5,19 @@ const MAX_ROUTE_ID_LENGTH = 20;
 // api.lad.lviv.ua vehicle -> the shape the frontend map expects.
 function toVehicles(raw, routeCode) {
     return raw.map((v) => ({
-        VehicleId: v.id,
-        X: v.location[1],
-        Y: v.location[0],
-        Angle: v.bearing,
-        RouteName: routeCode,
-        VehicleName: v.id,
+        id: v.id,
+        lat: v.location[0],
+        lng: v.location[1],
+        bearing: v.bearing,
+        routeCode,
+        name: v.id,
     }));
 }
 
 // static route shapes -> polyline points for the map.
 function toPath(shapes) {
     const firstShape = (shapes && shapes[0]) || [];
-    return firstShape.map(([lat, lng]) => ({ Y: lat, X: lng }));
+    return firstShape.map(([lat, lng]) => ({ lat, lng }));
 }
 
 function isValidRouteId(routeId) {

--- a/src/events.js
+++ b/src/events.js
@@ -1,25 +1,25 @@
 // Map update handlers. mapUtil is passed in rather than read from a global.
 
-export function defaultUpdate(mapUtil, data, routeCode) {
-    data.forEach((route) => {
-        const position = new google.maps.LatLng(route.Y, route.X);
+export function handleVehiclesUpdate(mapUtil, vehicles, routeCode) {
+    vehicles.forEach((vehicle) => {
+        const position = new google.maps.LatLng(vehicle.lat, vehicle.lng);
 
-        if (mapUtil.isMarkerOnMap(route.VehicleId)) {
-            mapUtil.moveMarker(mapUtil.getMarkerById(route.VehicleId), position);
+        if (mapUtil.isMarkerOnMap(vehicle.id)) {
+            mapUtil.moveMarker(mapUtil.getMarkerById(vehicle.id), position);
         } else {
-            const content = `Маршрут: <b>${route.RouteName}</b><br/>ТЗ: <b>${route.VehicleName}</b>`;
+            const content = `Маршрут: <b>${vehicle.routeCode}</b><br/>ТЗ: <b>${vehicle.name}</b>`;
             const infowindow = new google.maps.InfoWindow({ content, maxWidth: 500 });
-            mapUtil.addMarker(position, route.VehicleId, infowindow, route.Angle, routeCode);
+            mapUtil.addMarker(position, vehicle.id, infowindow, vehicle.bearing, routeCode);
         }
     });
 }
 
-export function drawRoute(mapUtil, data) {
-    const coordinates = data.path.map((p) => new google.maps.LatLng(p.Y, p.X));
-    mapUtil.drawPath(coordinates, data.code);
+export function handleRoutePath(mapUtil, { routeCode, path }) {
+    const coordinates = path.map((point) => new google.maps.LatLng(point.lat, point.lng));
+    mapUtil.drawPath(coordinates, routeCode);
 }
 
-export function eventRemoveRoute(mapUtil, routeCode) {
+export function clearRoute(mapUtil, routeCode) {
     mapUtil.removePath(routeCode);
     mapUtil.deleteMarkersByCode(routeCode);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,8 @@ import { io } from 'socket.io-client';
 import Hammer from 'hammerjs';
 import { createMap, MapUtil } from './map.js';
 import { installMarkerAnimate } from './markerAnimate.js';
-import { defaultUpdate, drawRoute, eventRemoveRoute } from './events.js';
+import { handleVehiclesUpdate, handleRoutePath, clearRoute } from './events.js';
+import Events from '../socket/events.js';
 
 let mapUtil = null;
 
@@ -36,17 +37,17 @@ function loadGoogleMaps(key) {
 function wireRouteToggles(socket) {
     document.querySelectorAll('#route_stops input').forEach((input) => {
         input.addEventListener('change', () => {
-            const code = input.value;
+            const routeCode = input.value;
             if (input.checked) {
-                socket.emit('add-bus', code, (res) => {
+                socket.emit(Events.ROUTE_SUBSCRIBE, routeCode, (res) => {
                     if (res && !res.ok) {
-                        console.error('add-bus failed:', res.error);
+                        console.error(`${Events.ROUTE_SUBSCRIBE} failed:`, res.error);
                         input.checked = false;
                     }
                 });
             } else {
-                socket.emit('remove-bus', code);
-                if (mapUtil) eventRemoveRoute(mapUtil, code);
+                socket.emit(Events.ROUTE_UNSUBSCRIBE, routeCode);
+                if (mapUtil) clearRoute(mapUtil, routeCode);
             }
         });
     });
@@ -74,8 +75,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const mapsKey = config ? config.dataset.mapsKey : '';
 
     const socket = io();
-    socket.on('defaultUpdate', (data, code) => { if (mapUtil) defaultUpdate(mapUtil, data, code); });
-    socket.on('drawRoute', (data) => { if (mapUtil) drawRoute(mapUtil, data); });
+    socket.on(Events.VEHICLES_UPDATE, (vehicles, routeCode) => {
+        if (mapUtil) handleVehiclesUpdate(mapUtil, vehicles, routeCode);
+    });
+    socket.on(Events.ROUTE_PATH, (data) => { if (mapUtil) handleRoutePath(mapUtil, data); });
 
     wireRouteToggles(socket);
     wireMenuSwipe();

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,24 +1,23 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-test('defaultUpdate is a finite number', () => {
+test('pollIntervalMs is a finite number', () => {
     const config = require('../config/index');
-    assert.equal(typeof config.defaultUpdate, 'number');
-    assert.ok(Number.isFinite(config.defaultUpdate), `expected finite number, got: ${config.defaultUpdate}`);
+    assert.equal(typeof config.pollIntervalMs, 'number');
+    assert.ok(Number.isFinite(config.pollIntervalMs), `expected finite number, got: ${config.pollIntervalMs}`);
 });
 
-test('defaultUpdate defaults to 5000 when DEFAULT_UPDATE env var is absent', () => {
-    const saved = process.env.DEFAULT_UPDATE;
-    delete process.env.DEFAULT_UPDATE;
+test('pollIntervalMs defaults to 5000 when POLL_INTERVAL_MS env var is absent', () => {
+    const saved = process.env.POLL_INTERVAL_MS;
+    delete process.env.POLL_INTERVAL_MS;
 
     const configPath = require.resolve('../config/index');
     delete require.cache[configPath];
     const freshConfig = require('../config/index');
 
-    assert.equal(freshConfig.defaultUpdate, 5000);
+    assert.equal(freshConfig.pollIntervalMs, 5000);
 
     // restore env and evict the fresh module so later tests see original state
-    if (saved !== undefined) process.env.DEFAULT_UPDATE = saved;
+    if (saved !== undefined) process.env.POLL_INTERVAL_MS = saved;
     delete require.cache[configPath];
 });
-

--- a/test/socket.integration.test.js
+++ b/test/socket.integration.test.js
@@ -6,9 +6,10 @@ const { io: ioClient } = require('socket.io-client');
 
 const Model = require('../models/model');
 const setupSocket = require('../socket');
+const Events = require('../socket/events');
 
 // These tests exercise the real Socket.IO event wiring in socket/index.js
-// (add-bus / remove-bus / disconnect / ack) with Model stubbed so no network
+// (route:subscribe / route:unsubscribe / disconnect / ack) with Model stubbed so no network
 // is hit. The pure tracking + transform logic is covered separately in
 // clientRegistry.test.js and transform.test.js.
 
@@ -43,49 +44,49 @@ function connect() {
     return ioClient(`http://localhost:${port}`, { forceNew: true, transports: ['websocket'] });
 }
 
-test('add-bus fetches the path, emits drawRoute, and acks ok', async () => {
+test('route:subscribe fetches the path, emits route:path, and acks ok', async () => {
     Model.getPathData = async () => ({
         getBody: () => JSON.stringify({ shapes: [[[49.84, 24.03], [49.85, 24.04]]] }),
     });
 
     const client = connect();
     try {
-        const drawRoute = new Promise((resolve) => client.on('drawRoute', resolve));
-        const ack = await client.emitWithAck('add-bus', '27');
-        const drawn = await drawRoute;
+        const routePath = new Promise((resolve) => client.on(Events.ROUTE_PATH, resolve));
+        const ack = await client.emitWithAck(Events.ROUTE_SUBSCRIBE, '27');
+        const drawn = await routePath;
 
         assert.deepEqual(ack, { ok: true });
-        assert.equal(drawn.code, '27');
-        assert.deepEqual(drawn.path, [{ Y: 49.84, X: 24.03 }, { Y: 49.85, X: 24.04 }]);
+        assert.equal(drawn.routeCode, '27');
+        assert.deepEqual(drawn.path, [{ lat: 49.84, lng: 24.03 }, { lat: 49.85, lng: 24.04 }]);
     } finally {
         client.disconnect();
     }
 });
 
-test('add-bus with an invalid route id acks an error and never draws', async () => {
+test('route:subscribe with an invalid route code acks an error and never emits a path', async () => {
     let pathCalled = false;
     Model.getPathData = async () => { pathCalled = true; return { getBody: () => '{}' }; };
 
     const client = connect();
     try {
-        let drew = false;
-        client.on('drawRoute', () => { drew = true; });
-        const ack = await client.emitWithAck('add-bus', 'x'.repeat(50));
+        let emittedPath = false;
+        client.on(Events.ROUTE_PATH, () => { emittedPath = true; });
+        const ack = await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'x'.repeat(50));
 
         assert.equal(ack.ok, false);
         assert.equal(pathCalled, false);
-        assert.equal(drew, false);
+        assert.equal(emittedPath, false);
     } finally {
         client.disconnect();
     }
 });
 
-test('add-bus acks an error when the path fetch fails', async () => {
+test('route:subscribe acks an error when the path fetch fails', async () => {
     Model.getPathData = async () => { throw new Error('upstream down'); };
 
     const client = connect();
     try {
-        const ack = await client.emitWithAck('add-bus', '27');
+        const ack = await client.emitWithAck(Events.ROUTE_SUBSCRIBE, '27');
         assert.equal(ack.ok, false);
         assert.match(ack.error, /upstream down/);
     } finally {

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -6,15 +6,15 @@ const { toVehicles, toPath, isValidRouteId } = require('../socket/transform');
 test('toVehicles maps api vehicles to the client shape', () => {
     const raw = [{ id: 'v1', location: [49.84, 24.03], bearing: 90 }];
     assert.deepEqual(toVehicles(raw, '27'), [
-        { VehicleId: 'v1', X: 24.03, Y: 49.84, Angle: 90, RouteName: '27', VehicleName: 'v1' },
+        { id: 'v1', lat: 49.84, lng: 24.03, bearing: 90, routeCode: '27', name: 'v1' },
     ]);
 });
 
-test('toPath maps shapes[0] lat/lng pairs to {Y, X} points', () => {
+test('toPath maps shapes[0] lat/lng pairs to {lat, lng} points', () => {
     const shapes = [[[49.84, 24.03], [49.85, 24.04]]];
     assert.deepEqual(toPath(shapes), [
-        { Y: 49.84, X: 24.03 },
-        { Y: 49.85, X: 24.04 },
+        { lat: 49.84, lng: 24.03 },
+        { lat: 49.85, lng: 24.04 },
     ]);
 });
 


### PR DESCRIPTION
Professionalizes the realtime protocol after #26. Internal/wire naming only - no behavior change.

## Event names (namespaced)
| before | after |
|---|---|
| `add-bus` | `route:subscribe` |
| `remove-bus` | `route:unsubscribe` |
| `drawRoute` | `route:path` |
| `defaultUpdate` | `vehicles:update` |

- New `socket/events.js`: frozen enum, single source of truth shared by the server (`require`) and the Vite-bundled client (`import`), so the wire contract can't drift between the two sides.

## Payloads (camelCase)
- Vehicle: `{VehicleId,X,Y,Angle,RouteName,VehicleName}` -> `{id,lat,lng,bearing,routeCode,name}`
- Path point: `{Y,X}` -> `{lat,lng}`
- `route:path` payload is now `{ routeCode, path }`

## Naming
- `config.defaultUpdate` -> `pollIntervalMs`; env `DEFAULT_UPDATE` -> `POLL_INTERVAL_MS`
- `route_id` -> `routeCode`; poll interval var -> `pollInterval`
- Client handlers -> `handleVehiclesUpdate` / `handleRoutePath` / `clearRoute`

## Docs + tests
- README protocol diagram, env table, tech stack, and project structure brought current (Vite, src/, e2e/, jQuery-free)
- Unit + integration tests updated to the new events/payloads

## Verification
- `npm test`: 32 pass, 2 skipped (offline)
- `npm run test:e2e`: 2 pass
- Build clean (67KB / 22KB gzip)
