### PR TITLE
chore: drop HammerJS, native touch swipe for sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Built in 2017 against the SimpleRIDE API provided by the Lviv transit authority.
 
 ## How it works
 
-The server fetches available bus routes from `api.lad.lviv.ua` on page load. When a user checks a route in the sidebar, the browser emits a Socket.IO event; the server draws the route path on the map and begins polling live vehicle positions every 5 seconds, pushing updates back to all subscribed clients. Markers animate smoothly as positions change. On mobile, the route sidebar supports swipe gestures via HammerJS.
+The server fetches available bus routes from `api.lad.lviv.ua` on page load. When a user checks a route in the sidebar, the browser emits a Socket.IO event; the server draws the route path on the map and begins polling live vehicle positions every 5 seconds, pushing updates back to all subscribed clients. Markers animate smoothly as positions change. On mobile, the route sidebar supports horizontal swipe gestures (native touch events).
 
 ```
 Browser ──(checkbox toggle)──> socket.emit('route:subscribe', routeCode)
@@ -29,7 +29,6 @@ Browser ──> animate markers on Google Map
 - dotenv (environment config)
 - Vite (frontend bundling; vanilla ES modules, no jQuery)
 - Google Maps JavaScript API
-- HammerJS 2 (mobile swipe gestures, bundled)
 - Bootstrap 3 (CSS only)
 
 ## Setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "dotenv": "^16.5.0",
         "ejs": "^6.0.1",
         "express": "^5.2.1",
-        "hammerjs": "^2.0.8",
         "morgan": "^1.11.0",
         "serve-favicon": "^2.5.1",
         "socket.io": "^4.8.3",
@@ -1018,15 +1017,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE= sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/has-symbols": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "dotenv": "^16.5.0",
     "ejs": "^6.0.1",
     "express": "^5.2.1",
-    "hammerjs": "^2.0.8",
     "morgan": "^1.11.0",
     "serve-favicon": "^2.5.1",
     "socket.io": "^4.8.3",

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,4 @@
 import { io } from 'socket.io-client';
-import Hammer from 'hammerjs';
 import { createMap, MapUtil } from './map.js';
 import { installMarkerAnimate } from './markerAnimate.js';
 import { handleVehiclesUpdate, handleRoutePath, clearRoute } from './events.js';
@@ -53,13 +52,28 @@ function wireRouteToggles(socket) {
     });
 }
 
+// Native horizontal-swipe handling for the route sidebar (replaces HammerJS).
 function wireMenuSwipe() {
     const menu = document.getElementById('menu');
     if (!menu) return;
-    const hammer = new Hammer.Manager(menu);
-    hammer.add(new Hammer.Swipe());
-    hammer.on('swipeleft', () => { menu.style.left = `${menu.offsetLeft - 100}px`; });
-    hammer.on('swiperight', () => { menu.style.left = `${menu.offsetLeft + 100}px`; });
+
+    const SWIPE_THRESHOLD = 40; // px
+    let startX = 0;
+    let startY = 0;
+
+    menu.addEventListener('touchstart', (e) => {
+        const touch = e.changedTouches[0];
+        startX = touch.clientX;
+        startY = touch.clientY;
+    }, { passive: true });
+
+    menu.addEventListener('touchend', (e) => {
+        const touch = e.changedTouches[0];
+        const dx = touch.clientX - startX;
+        const dy = touch.clientY - startY;
+        if (Math.abs(dx) < SWIPE_THRESHOLD || Math.abs(dx) <= Math.abs(dy)) return; // not a horizontal swipe
+        menu.style.left = `${menu.offsetLeft + (dx < 0 ? -100 : 100)}px`;
+    }, { passive: true });
 }
 
 // Replaces Bootstrap 3's jQuery-based collapse for the navbar toggle.


### PR DESCRIPTION
Removes the HammerJS dependency. It was used only for the route-sidebar swipe gesture.

## Changes
- Remove `hammerjs` dependency and its import
- Replace Hammer swipe with native `touchstart`/`touchend` horizontal-swipe detection (passive listeners, same nudge behavior, ignores vertical scrolls)
- README: drop HammerJS from tech stack + how-it-works prose

## Impact
- Bundle: **67KB -> 47KB** (gzip 22KB -> 15KB)
- One fewer runtime dependency

## Verification
- `npm test`: 32 pass, 2 skipped
- `npm run test:e2e`: 2 pass (page renders, no console errors, route toggle works)
- Build clean