### PR TITLE
chore: add render.yaml for Render.com deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: lviv-transit-tracker
+    runtime: node
+    plan: free
+    buildCommand: npm install --include=dev && npm run build
+    startCommand: node ./bin/www
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: GOOGLE_MAPS_KEY
+        sync: false


### PR DESCRIPTION
## Summary
- Adds `render.yaml` with Render.com web service config
- Build: `npm install --include=dev && npm run build` (vite is devDep, needs explicit include in production)
- Start: `node ./bin/www` (skips `prestart` hook to avoid double vite build)
- `GOOGLE_MAPS_KEY` marked `sync: false` - must be set manually in Render dashboard