### PR TITLE
refactor: drop getBody() shim, return parsed JSON from model

### DIFF
--- a/models/model.js
+++ b/models/model.js
@@ -11,8 +11,7 @@ async function get(url, timeout) {
             const body = await res.text();
             throw Object.assign(new Error(body), { code: res.status });
         }
-        const body = await res.text();
-        return { getBody: () => body };
+        return res.json();
     } finally {
         clearTimeout(id);
     }

--- a/routes/index.js
+++ b/routes/index.js
@@ -9,10 +9,7 @@ const routeCache = createCache();
 
 // Fetch + parse the route list, cached for routeCache's TTL.
 async function getRouteList() {
-    return routeCache.get(async () => {
-        const response = await model.getBuses();
-        return JSON.parse(response.getBody());
-    });
+    return routeCache.get(() => model.getBuses());
 }
 
 /* about page. */

--- a/socket/index.js
+++ b/socket/index.js
@@ -19,8 +19,7 @@ function setupSocket(io) {
 			registry.add(socket.id, routeCode);
 
 			try {
-				const response = await Model.getPathData(routeCode);
-				const routePathData = JSON.parse(response.getBody());
+				const routePathData = await Model.getPathData(routeCode);
 				const path = toPath(routePathData.shapes);
 				socket.emit(Events.ROUTE_PATH, { routeCode, path });
 				if (typeof ack === 'function') ack({ ok: true });
@@ -47,8 +46,7 @@ function setupSocket(io) {
 
 		for (const routeCode of routeCodes) {
 			try {
-				const response = await Model.getRoutes(routeCode);
-				const rawData = JSON.parse(response.getBody());
+				const rawData = await Model.getRoutes(routeCode);
 				const vehicles = toVehicles(rawData, routeCode);
 
 				for (const socketId of registry.subscribersOf(routeCode)) {

--- a/test/api.integration.test.js
+++ b/test/api.integration.test.js
@@ -8,17 +8,15 @@ const model = require('../models/model');
 const run = process.env.INTEGRATION === '1';
 
 test('getBuses returns a non-empty route list from the live API', { skip: !run }, async () => {
-    const res = await model.getBuses();
-    const routes = JSON.parse(res.getBody());
+    const routes = await model.getBuses();
     assert.ok(Array.isArray(routes), 'expected an array of routes');
     assert.ok(routes.length > 0, 'expected at least one route');
     assert.ok('short_name' in routes[0], `route shape: ${Object.keys(routes[0]).join(', ')}`);
 });
 
 test('getRoutes returns vehicle data for a live route code', { skip: !run }, async () => {
-    // Derive a real code from the route list so the test can't rot.
-    const routes = JSON.parse((await model.getBuses()).getBody());
+    const routes = await model.getBuses();
     const code = routes[0].short_name;
-    const vehicles = JSON.parse((await model.getRoutes(code)).getBody());
+    const vehicles = await model.getRoutes(code);
     assert.ok(Array.isArray(vehicles), `expected an array of vehicles for ${code}`);
 });

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -11,7 +11,7 @@ beforeEach(() => {
         capturedUrl = url;
         return {
             ok: true,
-            text: async () => '[{"id":1}]'
+            json: async () => [{ id: 1 }]
         };
     };
 });
@@ -20,10 +20,10 @@ afterEach(() => {
     delete global.fetch;
 });
 
-test('getBuses calls the bus endpoint and exposes body via getBody()', async () => {
-    const res = await model.getBuses();
+test('getBuses calls the bus endpoint and returns parsed JSON', async () => {
+    const routes = await model.getBuses();
     assert.ok(capturedUrl.includes('routes.json'), `URL was: ${capturedUrl}`);
-    assert.equal(res.getBody(), '[{"id":1}]');
+    assert.deepEqual(routes, [{ id: 1 }]);
 });
 
 test('getRoutes rejects with status code when server returns error', async () => {
@@ -34,13 +34,13 @@ test('getRoutes rejects with status code when server returns error', async () =>
     );
 });
 
-test('getPathData calls the static route endpoint', async () => {
-    const res = await model.getPathData('7');
+test('getPathData calls the static route endpoint and returns parsed JSON', async () => {
+    const data = await model.getPathData('7');
     assert.ok(capturedUrl.includes('/routes/static/'), `URL was: ${capturedUrl}`);
-    assert.equal(res.getBody(), '[{"id":1}]');
+    assert.deepEqual(data, [{ id: 1 }]);
 });
 
-test('getRoutes resolves and getBody() returns the mocked text', async () => {
-    const res = await model.getRoutes('15');
-    assert.equal(res.getBody(), '[{"id":1}]');
+test('getRoutes returns parsed JSON', async () => {
+    const data = await model.getRoutes('15');
+    assert.deepEqual(data, [{ id: 1 }]);
 });

--- a/test/socket.integration.test.js
+++ b/test/socket.integration.test.js
@@ -45,9 +45,7 @@ function connect() {
 }
 
 test('route:subscribe fetches the path, emits route:path, and acks ok', async () => {
-    Model.getPathData = async () => ({
-        getBody: () => JSON.stringify({ shapes: [[[49.84, 24.03], [49.85, 24.04]]] }),
-    });
+    Model.getPathData = async () => ({ shapes: [[[49.84, 24.03], [49.85, 24.04]]] });
 
     const client = connect();
     try {
@@ -65,7 +63,7 @@ test('route:subscribe fetches the path, emits route:path, and acks ok', async ()
 
 test('route:subscribe with an invalid route code acks an error and never emits a path', async () => {
     let pathCalled = false;
-    Model.getPathData = async () => { pathCalled = true; return { getBody: () => '{}' }; };
+    Model.getPathData = async () => { pathCalled = true; return {}; };
 
     const client = connect();
     try {


### PR DESCRIPTION
## Summary

- `Model.get()` now returns `res.json()` (parsed data) directly instead of the dead SimpleRIDE-era `{ getBody: () => body }` wrapper
- Removes `JSON.parse(response.getBody())` ceremony from every caller
- No behavior change - only the internal contract between model and callers

## Changed files

- `models/model.js` - `res.text()` + wrapper -> `res.json()`
- `routes/index.js` - `getRouteList()` simplified (no parse step)
- `socket/index.js` - both `getPathData` and `getRoutes` call sites cleaned up
- `test/model.test.js` - stubs now provide `json()`, assertions on parsed data
- `test/api.integration.test.js` - no more `.getBody()` in integration calls
- `test/socket.integration.test.js` - stubs return plain objects, not `{ getBody }`

## Test plan

- [x] `npm test` — 32 pass / 2 skipped (offline integration)