### PR TITLE
fix: console.log -> console.error in route handlers, drop unused next params

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -16,12 +16,12 @@ async function getRouteList() {
 }
 
 /* about page. */
-router.get('/about', function (req, res, next) {
+router.get('/about', function (req, res) {
     res.render('pages/about', { title: 'About', googleMapsKey: config.googleMapsKey });
 });
 
 /* GET home page. */
-router.get('/', async function (req, res, next) {
+router.get('/', async function (req, res) {
     const view_data = {title: 'LvivTransportMonitoringExpress', googleMapsKey: config.googleMapsKey};
 
     try {
@@ -45,22 +45,19 @@ router.get('/', async function (req, res, next) {
             errorMessage += " - " + error.code + ": " + error.message;
         }
 
-        console.log(error);
-        return res.status(400).send({
-            message: errorMessage
-        });
+        console.error(error);
+        return res.status(400).send({ message: errorMessage });
     }
 });
 
 /* GET Json Data */
-router.get('/json', async function (req, res, next) {
+router.get('/json', async function (req, res) {
     try {
         const json = await getRouteList();
         res.send(json);
     } catch (error) {
-        return res.status(500).send({
-            message: error.message || "Internal Server Error"
-        });
+        console.error(error);
+        return res.status(500).send({ message: error.message || "Internal Server Error" });
     }
 });
 


### PR DESCRIPTION
## Summary

- `console.log(error)` in `GET /` catch block -> `console.error` — errors belong on stderr
- `GET /json` catch was silently swallowing errors with no log — added `console.error`
- Dropped unused `next` parameter from all three route callbacks

No behavior change for callers. Tests: 32 pass / 2 skipped.