### PR TITLE
fix: harden realtime loop, reconnect, deploy and a11y (audit batch 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build frontend bundle
+        run: npm run build
+
       - name: Run tests
         run: npm test
+
+      - name: Audit dependencies
+        run: npm audit --audit-level=high
+        continue-on-error: true

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const favicon = require('serve-favicon');
 const logger = require('morgan');
-const cookieParser = require('cookie-parser');
+const compression = require('compression');
 
 const router = require('./routes');
 const setupSocket = require('./socket');
@@ -17,11 +17,11 @@ setupSocket(app.io);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 
+app.use(compression());
 app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({extended: false}));
-app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 //define routes

--- a/models/model.js
+++ b/models/model.js
@@ -11,7 +11,10 @@ async function get(url, timeout) {
             const body = await res.text();
             throw Object.assign(new Error(body), { code: res.status });
         }
-        return res.json();
+        // Awaited so the abort timer stays armed until the body is fully read.
+        // `return res.json()` would let `finally` clear the timeout before the
+        // (multi-MB) body finished downloading, leaving the read unprotected.
+        return await res.json();
     } finally {
         clearTimeout(id);
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "lviv-transport-monitoring-express",
+  "name": "lviv-transit-tracker",
   "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lviv-transport-monitoring-express",
+      "name": "lviv-transit-tracker",
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
-        "cookie-parser": "^1.4.7",
+        "compression": "^1.8.0",
         "debug": "^4.4.3",
         "dotenv": "^16.5.0",
         "ejs": "^6.0.1",
@@ -17,11 +17,11 @@
         "morgan": "^1.11.0",
         "serve-favicon": "^2.5.1",
         "socket.io": "^4.8.3",
-        "socket.io-client": "^4.8.3"
+        "socket.io-client": "^4.8.3",
+        "vite": "^8.1.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
-        "vite": "^8.1.0"
+        "@playwright/test": "^1.61.1"
       },
       "engines": {
         "node": ">=20"
@@ -31,7 +31,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -43,7 +42,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -54,7 +52,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -65,7 +62,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -84,7 +80,6 @@
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
       "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -113,7 +108,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -130,7 +124,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -147,7 +140,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -164,7 +156,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -181,7 +172,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -198,7 +188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -218,7 +207,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -238,7 +226,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -258,7 +245,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -278,7 +264,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -298,7 +283,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -318,7 +302,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -335,7 +318,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -354,7 +336,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -371,7 +352,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -385,7 +365,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@socket.io/component-emitter": {
@@ -398,7 +377,6 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -541,6 +519,80 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
@@ -571,25 +623,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/cookie-parser": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
-      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "0.7.2",
-        "cookie-signature": "1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw= sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.6",
@@ -638,7 +671,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -893,7 +925,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -950,7 +981,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1104,7 +1134,6 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -1137,7 +1166,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1158,7 +1186,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1179,7 +1206,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1200,7 +1226,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1221,7 +1246,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1242,7 +1266,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1266,7 +1289,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1290,7 +1312,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -1314,7 +1335,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -1338,7 +1358,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1359,7 +1378,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1473,7 +1491,6 @@
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1571,14 +1588,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1638,7 +1653,6 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1724,7 +1738,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.3.tgz",
       "integrity": "sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.137.0",
@@ -2053,7 +2066,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2072,7 +2084,6 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -2098,7 +2109,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -2161,7 +2171,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
       "integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "lviv-transport-monitoring-express",
+  "name": "lviv-transit-tracker",
   "version": "0.0.2",
   "private": true,
-  "description": "Real-time Lviv public transit tracker - bus positions on Google Maps via Socket.IO and the SimpleRIDE API",
+  "description": "Real-time Lviv public transit tracker - bus positions on Google Maps via Socket.IO and the api.lad.lviv.ua REST API",
   "keywords": [
     "lviv",
     "transit",
@@ -29,7 +29,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "cookie-parser": "^1.4.7",
+    "compression": "^1.8.0",
     "debug": "^4.4.3",
     "dotenv": "^16.5.0",
     "ejs": "^6.0.1",
@@ -37,10 +37,10 @@
     "morgan": "^1.11.0",
     "serve-favicon": "^2.5.1",
     "socket.io": "^4.8.3",
-    "socket.io-client": "^4.8.3"
+    "socket.io-client": "^4.8.3",
+    "vite": "^8.1.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
-    "vite": "^8.1.0"
+    "@playwright/test": "^1.61.1"
   }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -170,7 +170,7 @@ body.app-page {
 }
 
 .text-center { text-align: center; }
-.text-muted { color: #9aa0a6; }
+.text-muted { color: #b6bbc0; } /* >=4.5:1 on the #40464b page bg (WCAG AA) */
 
 /* Loading spinner while a route subscription is pending */
 .route-row.loading > label::before {

--- a/render.yaml
+++ b/render.yaml
@@ -3,10 +3,13 @@ services:
     name: lviv-transit-tracker
     runtime: node
     plan: free
-    buildCommand: npm install --include=dev && npm run build
+    buildCommand: npm ci && npm run build
     startCommand: node ./bin/www
+    healthCheckPath: /healthz
     envVars:
       - key: NODE_ENV
         value: production
+      - key: NODE_VERSION
+        value: 22
       - key: GOOGLE_MAPS_KEY
         sync: false

--- a/routes/index.js
+++ b/routes/index.js
@@ -12,6 +12,12 @@ async function getRouteList() {
     return routeCache.get(() => model.getBuses());
 }
 
+/* Liveness probe: no external I/O, so platform health checks stay decoupled
+   from upstream api.lad.lviv.ua availability. */
+router.get('/healthz', function (req, res) {
+    res.status(200).json({ status: 'ok' });
+});
+
 /* about page. */
 router.get('/about', function (req, res) {
     res.render('pages/about', { title: 'Про застосунок — Транспорт Львова Live', googleMapsKey: config.googleMapsKey });
@@ -48,7 +54,9 @@ router.get('/', async function (req, res) {
         }
 
         console.error(error);
-        return res.status(400).send({ message: errorMessage });
+        // Upstream/gateway failure, not a client error -> 502, so monitoring and
+        // any health check keying on 5xx classify it correctly.
+        return res.status(502).send({ message: errorMessage });
     }
 });
 

--- a/services/routeCache.js
+++ b/services/routeCache.js
@@ -24,6 +24,13 @@ function createCache({ ttl = 5 * 60 * 1000, now = Date.now } = {}) {
             })();
             try {
                 return await inFlight;
+            } catch (err) {
+                // Serve-stale-on-error: a brief upstream outage shouldn't take
+                // the page down when a slightly-stale list is still in memory.
+                // Only propagate when there's no previously-good value to fall
+                // back to (cold cache).
+                if (value !== null) return value;
+                throw err;
             } finally {
                 inFlight = null;
             }

--- a/socket/index.js
+++ b/socket/index.js
@@ -6,7 +6,7 @@ const createRegistry = require('./clientRegistry');
 const { toVehicles, toPath, isValidRouteId } = require('./transform');
 const Events = require('./events');
 
-function setupSocket(io) {
+function setupSocket(io, { pollIntervalMs = config.pollIntervalMs } = {}) {
 	const registry = createRegistry();
 
 	io.on('connection', function (socket) {
@@ -39,12 +39,13 @@ function setupSocket(io) {
 		});
 	});
 
-	// poll active routes and push vehicle updates to their subscribers
-	const pollInterval = setInterval(async function () {
+	// One poll cycle: fetch every active route concurrently and push updates.
+	// Per-route try/catch so a single failing route never rejects the batch.
+	async function pollOnce() {
 		const routeCodes = registry.activeRoutes();
 		if (routeCodes.size === 0) return;
 
-		for (const routeCode of routeCodes) {
+		await Promise.allSettled([...routeCodes].map(async (routeCode) => {
 			try {
 				const rawData = await Model.getRoutes(routeCode);
 				const vehicles = toVehicles(rawData, routeCode);
@@ -55,10 +56,40 @@ function setupSocket(io) {
 			} catch (err) {
 				console.error(`${Events.VEHICLES_UPDATE} error for route`, routeCode, ':', err);
 			}
-		}
-	}, config.pollIntervalMs).unref();
+		}));
+	}
 
-	return pollInterval;
+	// Self-scheduling loop instead of setInterval: the next cycle is scheduled
+	// only after the current one settles, so a slow upstream can never stack
+	// overlapping cycles (which previously caused duplicate emits + request
+	// amplification against an already-degraded API).
+	let pollTimer = null;
+	let stopped = false;
+
+	function scheduleNext() {
+		if (stopped) return;
+		pollTimer = setTimeout(async () => {
+			try {
+				await pollOnce();
+			} finally {
+				scheduleNext();
+			}
+		}, pollIntervalMs);
+		pollTimer.unref();
+	}
+
+	scheduleNext();
+
+	return {
+		// Stops the poll loop and clears any pending timer (used on shutdown).
+		stop() {
+			stopped = true;
+			if (pollTimer) clearTimeout(pollTimer);
+		},
+		// Runs a single poll cycle on demand (used by tests to trigger a tick
+		// deterministically without waiting for the interval).
+		pollOnce,
+	};
 }
 
 module.exports = setupSocket;

--- a/socket/transform.js
+++ b/socket/transform.js
@@ -3,15 +3,21 @@
 const MAX_ROUTE_ID_LENGTH = 20;
 
 // api.lad.lviv.ua vehicle -> the shape the frontend map expects.
+// Guards against a malformed upstream payload (non-array, or vehicles with no
+// location): a bad response degrades to an empty update instead of throwing a
+// TypeError that the poll loop would swallow, silently killing the route.
 function toVehicles(raw, routeCode) {
-    return raw.map((v) => ({
-        id: v.id,
-        lat: v.location[0],
-        lng: v.location[1],
-        bearing: v.bearing,
-        routeCode,
-        name: v.id,
-    }));
+    const list = Array.isArray(raw) ? raw : [];
+    return list
+        .filter((v) => v && Array.isArray(v.location) && v.location.length >= 2)
+        .map((v) => ({
+            id: v.id,
+            lat: v.location[0],
+            lng: v.location[1],
+            bearing: v.bearing,
+            routeCode,
+            name: v.id,
+        }));
 }
 
 // static route shapes -> polyline points for the map.

--- a/src/events.js
+++ b/src/events.js
@@ -12,6 +12,10 @@ export function handleVehiclesUpdate(mapUtil, vehicles, routeCode) {
             mapUtil.addMarker(position, vehicle.id, infowindow, vehicle.bearing, routeCode);
         }
     });
+
+    // Drop markers for vehicles that fell out of this update (ended shift /
+    // stopped reporting) so they don't linger frozen and accumulate.
+    mapUtil.reconcileRoute(routeCode, new Set(vehicles.map((v) => v.id)));
 }
 
 export function handleRoutePath(mapUtil, { routeCode, path }) {

--- a/src/main.js
+++ b/src/main.js
@@ -104,7 +104,28 @@ function wireNavbarToggle() {
     const toggle = document.querySelector('.navbar-toggle');
     const target = document.getElementById('navbar');
     if (!toggle || !target) return;
-    toggle.addEventListener('click', () => target.classList.toggle('in'));
+    toggle.addEventListener('click', () => {
+        const open = target.classList.toggle('in');
+        toggle.setAttribute('aria-expanded', String(open));
+    });
+}
+
+// Re-subscribes every checked route. Runs on every (re)connect: the server
+// tracks subscriptions per socket.id and purges them on disconnect, so without
+// this a reconnect (deploy, network blip) leaves checkboxes checked while the
+// map silently stops updating.
+function resubscribeChecked(socket) {
+    document.querySelectorAll('#route_stops input:checked').forEach((input) => {
+        const row = input.closest('.route-row');
+        if (row) row.classList.add('loading');
+        socket.emit(Events.ROUTE_SUBSCRIBE, input.value, (res) => {
+            if (res && !res.ok) {
+                console.error(`${Events.ROUTE_SUBSCRIBE} failed:`, res.error);
+                input.checked = false;
+                if (row) row.classList.remove('loading');
+            }
+        });
+    });
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -112,6 +133,20 @@ document.addEventListener('DOMContentLoaded', () => {
     const mapsKey = config ? config.dataset.mapsKey : '';
 
     const socket = io();
+
+    // On reconnect the old map state is stale and the server has no record of
+    // our subscriptions: clear what's drawn, then re-subscribe the checked
+    // routes. The first connect is a no-op clear with nothing checked yet.
+    let connectedBefore = false;
+    socket.on('connect', () => {
+        if (connectedBefore && mapUtil) {
+            mapUtil.deleteMarkers();
+            mapUtil.clearPaths();
+        }
+        connectedBefore = true;
+        resubscribeChecked(socket);
+    });
+
     socket.on(Events.VEHICLES_UPDATE, (vehicles, routeCode) => {
         clearLoading(routeCode);
         if (mapUtil) handleVehiclesUpdate(mapUtil, vehicles, routeCode);

--- a/src/map.js
+++ b/src/map.js
@@ -110,4 +110,21 @@ export class MapUtil {
             }
         }
     }
+
+    // Removes markers for `code` whose vehicle id is no longer in `keepIds`,
+    // so buses that stopped reporting don't stay frozen on the map (and leak
+    // their marker + InfoWindow + click listener) for the rest of the session.
+    reconcileRoute(code, keepIds) {
+        for (const [id, marker] of this.markers) {
+            if (marker.routeCode === code && !keepIds.has(id)) {
+                marker.setMap(null);
+                this.markers.delete(id);
+            }
+        }
+    }
+
+    clearPaths() {
+        for (const mapPath of this.paths.values()) mapPath.setMap(null);
+        this.paths.clear();
+    }
 }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -44,3 +44,8 @@ test('getRoutes returns parsed JSON', async () => {
     const data = await model.getRoutes('15');
     assert.deepEqual(data, [{ id: 1 }]);
 });
+
+test('a failure while reading the body propagates (json is awaited under the timeout)', async () => {
+    global.fetch = async () => ({ ok: true, json: async () => { throw new Error('body read aborted'); } });
+    await assert.rejects(() => model.getRoutes('15'), /body read aborted/);
+});

--- a/test/routeCache.test.js
+++ b/test/routeCache.test.js
@@ -51,3 +51,13 @@ test('a rejected fetch is not cached; next call retries', async () => {
     assert.equal(val, 'ok');
     assert.equal(calls, 2);
 });
+
+test('serves the last good value when a post-ttl refresh fails (serve-stale-on-error)', async () => {
+    let clock = 0;
+    const cache = createCache({ ttl: 1000, now: () => clock });
+    await cache.get(async () => 'fresh');
+
+    clock = 2000; // past ttl, forces a refresh
+    const val = await cache.get(async () => { throw new Error('upstream down'); });
+    assert.equal(val, 'fresh'); // stale value served instead of throwing
+});

--- a/test/socket.integration.test.js
+++ b/test/socket.integration.test.js
@@ -15,7 +15,7 @@ const Events = require('../socket/events');
 
 let httpServer;
 let io;
-let interval;
+let socketCtl;
 let port;
 
 const origGetPathData = Model.getPathData;
@@ -24,13 +24,15 @@ const origGetRoutes = Model.getRoutes;
 before(async () => {
     httpServer = http.createServer();
     io = new Server(httpServer);
-    interval = setupSocket(io);
+    // Long interval so the auto-loop never fires during tests; cycles are
+    // driven deterministically via socketCtl.pollOnce().
+    socketCtl = setupSocket(io, { pollIntervalMs: 60000 });
     await new Promise((resolve) => httpServer.listen(0, resolve));
     port = httpServer.address().port;
 });
 
 after(() => {
-    clearInterval(interval);
+    socketCtl.stop();
     io.close();
     httpServer.close();
 });
@@ -89,5 +91,55 @@ test('route:subscribe acks an error when the path fetch fails', async () => {
         assert.match(ack.error, /upstream down/);
     } finally {
         client.disconnect();
+    }
+});
+
+test('poll cycle fetches active routes and pushes vehicles:update to subscribers', async () => {
+    Model.getPathData = async () => ({ shapes: [[[49.84, 24.03]]] });
+    Model.getRoutes = async () => [{ id: 'bus1', location: [49.84, 24.03], bearing: 90 }];
+
+    const client = connect();
+    try {
+        await client.emitWithAck(Events.ROUTE_SUBSCRIBE, '27');
+
+        const update = new Promise((resolve) =>
+            client.on(Events.VEHICLES_UPDATE, (vehicles, routeCode) => resolve({ vehicles, routeCode })));
+
+        await socketCtl.pollOnce();
+
+        const { vehicles, routeCode } = await update;
+        assert.equal(routeCode, '27');
+        assert.deepEqual(vehicles, [
+            { id: 'bus1', lat: 49.84, lng: 24.03, bearing: 90, routeCode: '27', name: 'bus1' },
+        ]);
+    } finally {
+        client.disconnect();
+    }
+});
+
+test('a route whose fetch throws does not abort the cycle for other routes', async () => {
+    Model.getPathData = async () => ({ shapes: [[[49.84, 24.03]]] });
+    Model.getRoutes = async (code) => {
+        if (code === 'bad') throw new Error('upstream 500');
+        return [{ id: 'busA', location: [49.84, 24.03], bearing: 0 }];
+    };
+
+    const good = connect();
+    const bad = connect();
+    try {
+        await bad.emitWithAck(Events.ROUTE_SUBSCRIBE, 'bad');
+        await good.emitWithAck(Events.ROUTE_SUBSCRIBE, '5');
+
+        const update = new Promise((resolve) =>
+            good.on(Events.VEHICLES_UPDATE, (vehicles, routeCode) => resolve({ vehicles, routeCode })));
+
+        await socketCtl.pollOnce();
+
+        const { routeCode, vehicles } = await update;
+        assert.equal(routeCode, '5');
+        assert.equal(vehicles[0].id, 'busA');
+    } finally {
+        good.disconnect();
+        bad.disconnect();
     }
 });

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -10,6 +10,24 @@ test('toVehicles maps api vehicles to the client shape', () => {
     ]);
 });
 
+test('toVehicles drops entries with no valid location instead of throwing', () => {
+    const raw = [
+        { id: 'ok', location: [49.84, 24.03], bearing: 10 },
+        { id: 'noLoc' },
+        { id: 'badLoc', location: null },
+        { id: 'shortLoc', location: [49.84] },
+    ];
+    assert.deepEqual(toVehicles(raw, '27'), [
+        { id: 'ok', lat: 49.84, lng: 24.03, bearing: 10, routeCode: '27', name: 'ok' },
+    ]);
+});
+
+test('toVehicles returns an empty array for a non-array payload', () => {
+    assert.deepEqual(toVehicles(undefined, '27'), []);
+    assert.deepEqual(toVehicles({ error: 'boom' }, '27'), []);
+    assert.deepEqual(toVehicles([], '27'), []);
+});
+
 test('toPath maps shapes[0] lat/lng pairs to {lat, lng} points', () => {
     const shapes = [[[49.84, 24.03], [49.85, 24.04]]];
     assert.deepEqual(toPath(shapes), [

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -11,7 +11,7 @@
 
 <div id="map"></div>
 <div id="menu">
-    <input id="route-search" type="search" placeholder="Пошук маршруту..." autocomplete="off"/>
+    <input id="route-search" type="search" placeholder="Пошук маршруту..." aria-label="Пошук маршруту" autocomplete="off"/>
     <div id="route_stops">
         <% routes.forEach(function (route) { %>
         <div class="route-row" title="<%= route['Name'] %>" data-name="<%= route['Name'] %>" data-code="<%= route['Code'] %>">


### PR DESCRIPTION
First batch from a 10-agent audit of the repo (65 findings total, each adversarially verified against the code). This PR ships the high-value, low-risk correctness/resilience/infra/a11y fixes. Security hardening and docs are deferred to follow-up PRs.

## Correctness / resilience
- **Poll loop overlap** (`socket/index.js`): replaced `setInterval(async …)` with a self-scheduling `setTimeout` + in-flight guard, and fetch active routes concurrently via `Promise.allSettled`. A slow upstream could previously stack overlapping cycles → duplicate `vehicles:update` emits + request amplification. `setupSocket` now returns `{ stop, pollOnce }`.
- **Abort timeout** (`models/model.js`): `return await res.json()` so the abort timer stays armed until the multi-MB body is read, not just the headers.
- **Malformed payload** (`socket/transform.js`): `toVehicles` guards non-array / location-less input so a bad upstream response degrades to an empty update instead of a thrown-and-swallowed `TypeError` that silently kills the route.
- **Serve-stale cache** (`services/routeCache.js`): on a post-TTL refresh failure, serve the last good value instead of 500ing the home page during a brief upstream blip.
- **Reconnect re-subscribe** (`src/main.js`): the client now re-emits subscriptions and clears stale map state on every (re)connect. Fixes the map silently freezing forever after any socket drop (deploy, network blip).
- **Stale markers** (`src/events.js`, `src/map.js`): `reconcileRoute` removes markers for vehicles that fall out of an update, fixing the frozen-marker memory/visual leak.
- **Status codes** (`routes/index.js`): upstream failure on `GET /` returns `502` (was `400`); added a `/healthz` liveness route with no external I/O.

## Infra / deploy / CI
- Added `compression` middleware; removed dead `cookie-parser` dependency.
- Renamed package to `lviv-transit-tracker`; fixed description (dead SimpleRIDE API → `api.lad.lviv.ua`).
- Moved `vite` to `dependencies` so Render builds with `npm ci`; pinned `NODE_VERSION=22`; added `healthCheckPath: /healthz`.
- CI now runs `npm run build` and a non-blocking `npm audit`.

## Accessibility
- Navbar toggle updates `aria-expanded`; route search gets an `aria-label`; footer muted text raised to WCAG AA contrast.

## Tests
Added poll-cycle + per-route-failure integration tests, `toVehicles` guard cases, routeCache serve-stale, and model body-read propagation. **41 pass, 0 fail** (was 35). `vite build` green; `/healthz` returns 200.

## Deferred to follow-ups
- **Security:** socket subscription validation + per-socket cap + rate limit + Socket.IO CORS, helmet + CSP, InfoWindow XSS escape, SIGTERM graceful shutdown + `unhandledRejection`, Socket.IO rooms.
- **UX/a11y:** mobile-menu open/closed states, keyboard-accessible route checkboxes (need visual verification).
- **Docs:** CONTRIBUTING/SECURITY/issue templates, demo.webp shrink, Dependabot.
