### PR TITLE
feat: security hardening - socket guards, helmet, XSS, graceful shutdown (audit batch 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,6 @@ PORT=3000
 POLL_INTERVAL_MS=5000
 # Google Maps JavaScript API key (restrict by HTTP referrer in Google Cloud Console)
 GOOGLE_MAPS_KEY=
+# Comma-separated browser origins allowed to open a Socket.IO connection.
+# Leave empty to use the built-in defaults (prod URL in production, localhost in dev).
+ALLOWED_ORIGINS=

--- a/app.js
+++ b/app.js
@@ -3,20 +3,37 @@ const path = require('path');
 const favicon = require('serve-favicon');
 const logger = require('morgan');
 const compression = require('compression');
+const helmet = require('helmet');
 
+const config = require('./config');
 const router = require('./routes');
 const setupSocket = require('./socket');
 
 const app = express();
 
-app.io = require('socket.io')();
+// Restrict which browser origins may open a Socket.IO connection, so other
+// sites can't drive the server cross-origin. Defaults to the prod URL in
+// production and localhost in dev; override with ALLOWED_ORIGINS.
+const corsOrigins = config.allowedOrigins.length
+	? config.allowedOrigins
+	: (config.isProduction
+		? ['https://lviv-transit-tracker.onrender.com']
+		: ['http://localhost:3000', 'http://127.0.0.1:3000']);
 
-setupSocket(app.io);
+app.io = require('socket.io')({ cors: { origin: corsOrigins, methods: ['GET', 'POST'] } });
+
+app.socketCtl = setupSocket(app.io);
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'ejs');
 
+// Security headers. CSP is intentionally disabled: a policy strict enough to be
+// useful must be tuned for the Google Maps JS API and verified in-browser with a
+// Maps key, which the referrer-restricted key prevents locally (follow-up). The
+// rest of helmet's defaults (frame protection, nosniff, referrer-policy, HSTS,
+// no x-powered-by) ship now.
+app.use(helmet({ contentSecurityPolicy: false }));
 app.use(compression());
 app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));

--- a/bin/www
+++ b/bin/www
@@ -16,6 +16,32 @@ server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
 
+// Render sends SIGTERM on every deploy/restart and waits ~30s before SIGKILL.
+// Drain instead of hard-dropping in-flight requests and live sockets.
+let shuttingDown = false;
+function shutdown(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`${signal} received, shutting down`);
+    if (app.socketCtl) app.socketCtl.stop();
+    app.io.close();
+    server.close(() => process.exit(0));
+    // Force-exit if connections don't drain in time.
+    setTimeout(() => process.exit(1), 10000).unref();
+}
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));
+
+// Last-resort safety net so a stray rejection/throw becomes a logged line (and
+// a clean restart) instead of silent downtime.
+process.on('unhandledRejection', (reason) => {
+    console.error('unhandledRejection:', reason);
+});
+process.on('uncaughtException', (err) => {
+    console.error('uncaughtException:', err);
+    process.exit(1);
+});
+
 function normalizePort(val) {
     const p = parseInt(val, 10);
     if (isNaN(p)) return val;

--- a/config/index.js
+++ b/config/index.js
@@ -7,4 +7,10 @@ module.exports = {
     port: parseInt(process.env.PORT) || 3000,
     googleMapsKey: process.env.GOOGLE_MAPS_KEY || '',
     apiBaseUrl: process.env.API_BASE_URL || 'https://api.lad.lviv.ua',
+    isProduction: process.env.NODE_ENV === 'production',
+    // Allowed browser origins for Socket.IO CORS (comma-separated env override).
+    allowedOrigins: (process.env.ALLOWED_ORIGINS || '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "dotenv": "^16.5.0",
         "ejs": "^6.0.1",
         "express": "^5.2.1",
+        "helmet": "^8.2.0",
         "morgan": "^1.11.0",
         "serve-favicon": "^2.5.1",
         "socket.io": "^4.8.3",
@@ -1071,6 +1072,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dotenv": "^16.5.0",
     "ejs": "^6.0.1",
     "express": "^5.2.1",
+    "helmet": "^8.2.0",
     "morgan": "^1.11.0",
     "serve-favicon": "^2.5.1",
     "socket.io": "^4.8.3",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,16 +1,8 @@
 const express = require('express');
 const router = express.Router();
 
-const model = require('../models/model');
 const config = require('../config');
-const createCache = require('../services/routeCache');
-
-const routeCache = createCache();
-
-// Fetch + parse the route list, cached for routeCache's TTL.
-async function getRouteList() {
-    return routeCache.get(() => model.getBuses());
-}
+const routeList = require('../services/routeList');
 
 /* Liveness probe: no external I/O, so platform health checks stay decoupled
    from upstream api.lad.lviv.ua availability. */
@@ -33,7 +25,7 @@ router.get('/', async function (req, res) {
     const view_data = {title: 'Транспорт Львова Live - відстеження транспорту онлайн', googleMapsKey: config.googleMapsKey};
 
     try {
-        const routes = await getRouteList();
+        const routes = await routeList.getRoutes();
 
         // Build view objects without mutating the cached list (shared with /json).
         view_data.routes = routes.map(function (route) {
@@ -63,7 +55,7 @@ router.get('/', async function (req, res) {
 /* GET Json Data */
 router.get('/json', async function (req, res) {
     try {
-        const json = await getRouteList();
+        const json = await routeList.getRoutes();
         res.send(json);
     } catch (error) {
         console.error(error);

--- a/services/routeList.js
+++ b/services/routeList.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const model = require('../models/model');
+const createCache = require('./routeCache');
+
+// Single shared TTL cache for the route list, used by both the HTTP routes
+// (home page / JSON) and the socket layer (valid-route-code validation), so a
+// cold cache under load only hits the upstream API once.
+const cache = createCache();
+
+function getRoutes() {
+    return cache.get(() => model.getBuses());
+}
+
+// Set of valid route codes (short_name), used to reject subscriptions to
+// arbitrary codes before any upstream fetch is issued.
+async function getValidCodes() {
+    const routes = await getRoutes();
+    return new Set(routes.map((r) => String(r.short_name)));
+}
+
+module.exports = { getRoutes, getValidCodes };

--- a/socket/clientRegistry.js
+++ b/socket/clientRegistry.js
@@ -14,6 +14,12 @@ function createRegistry() {
         remove(socketId, route) {
             clients.get(socketId)?.delete(route);
         },
+        count(socketId) {
+            return clients.get(socketId)?.size ?? 0;
+        },
+        has(socketId, route) {
+            return clients.get(socketId)?.has(route) ?? false;
+        },
         disconnect(socketId) {
             clients.delete(socketId);
         },

--- a/socket/index.js
+++ b/socket/index.js
@@ -2,40 +2,87 @@
 
 const Model = require('../models/model');
 const config = require('../config');
+const routeList = require('../services/routeList');
 const createRegistry = require('./clientRegistry');
 const { toVehicles, toPath, isValidRouteId } = require('./transform');
 const Events = require('./events');
 
-function setupSocket(io, { pollIntervalMs = config.pollIntervalMs } = {}) {
+// A route code must be in the live route list, not merely a well-formed string.
+// Rejects on failure (the home page hosting the socket has already warmed the
+// shared route-list cache, so a transient upstream blip serves the stale set).
+async function defaultIsKnownRoute(code) {
+	try {
+		return (await routeList.getValidCodes()).has(String(code));
+	} catch {
+		return false;
+	}
+}
+
+// Per-socket sliding-window limiter to stop subscribe-event spam.
+function createRateLimiter({ points, windowMs }) {
+	const hits = new Map(); // socketId -> timestamps[]
+	return {
+		allow(socketId, now) {
+			const recent = (hits.get(socketId) || []).filter((t) => now - t < windowMs);
+			if (recent.length >= points) {
+				hits.set(socketId, recent);
+				return false;
+			}
+			recent.push(now);
+			hits.set(socketId, recent);
+			return true;
+		},
+		forget(socketId) {
+			hits.delete(socketId);
+		},
+	};
+}
+
+function setupSocket(io, {
+	pollIntervalMs = config.pollIntervalMs,
+	isKnownRoute = defaultIsKnownRoute,
+	maxRoutesPerSocket = 50,
+	subscribeRateLimit = { points: 30, windowMs: 10000 },
+} = {}) {
 	const registry = createRegistry();
+	const limiter = subscribeRateLimit ? createRateLimiter(subscribeRateLimit) : null;
 
 	io.on('connection', function (socket) {
 		// subscribe to a route: send its path once, then stream vehicle updates
 		socket.on(Events.ROUTE_SUBSCRIBE, async function (routeCode, ack) {
-			if (!isValidRouteId(routeCode)) {
-				if (typeof ack === 'function') ack({ ok: false, error: 'invalid route code' });
-				return;
+			const reject = (error) => { if (typeof ack === 'function') ack({ ok: false, error }); };
+
+			if (!isValidRouteId(routeCode)) return reject('invalid route code');
+			if (limiter && !limiter.allow(socket.id, Date.now())) return reject('rate limited');
+			if (registry.count(socket.id) >= maxRoutesPerSocket && !registry.has(socket.id, routeCode)) {
+				return reject('subscription limit reached');
 			}
-			registry.add(socket.id, routeCode);
+			if (!(await isKnownRoute(routeCode))) return reject('unknown route code');
 
 			try {
 				const routePathData = await Model.getPathData(routeCode);
 				const path = toPath(routePathData.shapes);
+				// Register + join the room only after a successful path fetch, so a
+				// failed subscribe never leaves an active subscription being polled.
+				registry.add(socket.id, routeCode);
+				socket.join(routeCode);
 				socket.emit(Events.ROUTE_PATH, { routeCode, path });
 				if (typeof ack === 'function') ack({ ok: true });
 			} catch (err) {
 				console.error(`${Events.ROUTE_SUBSCRIBE} error:`, err);
-				if (typeof ack === 'function') ack({ ok: false, error: err.message });
+				reject(err.message);
 			}
 		});
 
 		// unsubscribe from a route
 		socket.on(Events.ROUTE_UNSUBSCRIBE, function (routeCode) {
 			registry.remove(socket.id, routeCode);
+			socket.leave(routeCode);
 		});
 
 		socket.on('disconnect', function () {
 			registry.disconnect(socket.id);
+			if (limiter) limiter.forget(socket.id);
 		});
 	});
 
@@ -50,9 +97,8 @@ function setupSocket(io, { pollIntervalMs = config.pollIntervalMs } = {}) {
 				const rawData = await Model.getRoutes(routeCode);
 				const vehicles = toVehicles(rawData, routeCode);
 
-				for (const socketId of registry.subscribersOf(routeCode)) {
-					io.sockets.sockets.get(socketId)?.emit(Events.VEHICLES_UPDATE, vehicles, routeCode);
-				}
+				// Encoded once and fanned out by Socket.IO to everyone in the room.
+				io.to(routeCode).emit(Events.VEHICLES_UPDATE, vehicles, routeCode);
 			} catch (err) {
 				console.error(`${Events.VEHICLES_UPDATE} error for route`, routeCode, ':', err);
 			}

--- a/src/events.js
+++ b/src/events.js
@@ -1,5 +1,21 @@
 // Map update handlers. mapUtil is passed in rather than read from a global.
 
+// Builds the InfoWindow body with DOM + textContent so route/vehicle values
+// (which originate from upstream/client-supplied data) can never inject markup.
+function buildInfoContent(vehicle) {
+    const el = document.createElement('div');
+    const rows = [['Маршрут: ', vehicle.routeCode], ['ТЗ: ', vehicle.name]];
+    for (const [label, value] of rows) {
+        const row = document.createElement('div');
+        row.append(label);
+        const strong = document.createElement('b');
+        strong.textContent = value;
+        row.append(strong);
+        el.append(row);
+    }
+    return el;
+}
+
 export function handleVehiclesUpdate(mapUtil, vehicles, routeCode) {
     vehicles.forEach((vehicle) => {
         const position = new google.maps.LatLng(vehicle.lat, vehicle.lng);
@@ -7,8 +23,7 @@ export function handleVehiclesUpdate(mapUtil, vehicles, routeCode) {
         if (mapUtil.isMarkerOnMap(vehicle.id)) {
             mapUtil.moveMarker(mapUtil.getMarkerById(vehicle.id), position);
         } else {
-            const content = `Маршрут: <b>${vehicle.routeCode}</b><br/>ТЗ: <b>${vehicle.name}</b>`;
-            const infowindow = new google.maps.InfoWindow({ content, maxWidth: 500 });
+            const infowindow = new google.maps.InfoWindow({ content: buildInfoContent(vehicle), maxWidth: 500 });
             mapUtil.addMarker(position, vehicle.id, infowindow, vehicle.bearing, routeCode);
         }
     });

--- a/test/clientRegistry.test.js
+++ b/test/clientRegistry.test.js
@@ -35,6 +35,19 @@ test('disconnect clears all routes for a client (no zombie routes)', () => {
     assert.deepEqual([...reg.activeRoutes()], []);
 });
 
+test('count and has reflect a client\'s subscriptions', () => {
+    const reg = createRegistry();
+    assert.equal(reg.count('sock1'), 0);
+    assert.equal(reg.has('sock1', '27'), false);
+    reg.add('sock1', '27');
+    reg.add('sock1', '3a');
+    assert.equal(reg.count('sock1'), 2);
+    assert.equal(reg.has('sock1', '27'), true);
+    assert.equal(reg.has('sock1', '99'), false);
+    reg.remove('sock1', '27');
+    assert.equal(reg.count('sock1'), 1);
+});
+
 test('subscribersOf lists socket ids subscribed to a route', () => {
     const reg = createRegistry();
     reg.add('sock1', '27');

--- a/test/socket.integration.test.js
+++ b/test/socket.integration.test.js
@@ -25,8 +25,9 @@ before(async () => {
     httpServer = http.createServer();
     io = new Server(httpServer);
     // Long interval so the auto-loop never fires during tests; cycles are
-    // driven deterministically via socketCtl.pollOnce().
-    socketCtl = setupSocket(io, { pollIntervalMs: 60000 });
+    // driven deterministically via socketCtl.pollOnce(). isKnownRoute is stubbed
+    // so route validation doesn't reach the network (covered in socketSecurity).
+    socketCtl = setupSocket(io, { pollIntervalMs: 60000, isKnownRoute: async () => true });
     await new Promise((resolve) => httpServer.listen(0, resolve));
     port = httpServer.address().port;
 });

--- a/test/socketSecurity.test.js
+++ b/test/socketSecurity.test.js
@@ -1,0 +1,127 @@
+const { test, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const { Server } = require('socket.io');
+const { io: ioClient } = require('socket.io-client');
+
+const Model = require('../models/model');
+const setupSocket = require('../socket');
+const Events = require('../socket/events');
+
+// Exercises the subscribe-time guards added in the security pass: route-code
+// validation against the known list, the per-socket subscription cap, and the
+// per-socket subscribe rate limit. Model is stubbed so no network is hit.
+
+let httpServer;
+let io;
+let socketCtl;
+let port;
+
+const origGetPathData = Model.getPathData;
+
+before(async () => {
+    httpServer = http.createServer();
+    io = new Server(httpServer);
+    socketCtl = setupSocket(io, {
+        pollIntervalMs: 60000,
+        isKnownRoute: async (code) => code === 'known',
+        maxRoutesPerSocket: 2,
+        subscribeRateLimit: { points: 3, windowMs: 60000 },
+    });
+    await new Promise((resolve) => httpServer.listen(0, resolve));
+    port = httpServer.address().port;
+});
+
+after(() => {
+    socketCtl.stop();
+    io.close();
+    httpServer.close();
+});
+
+beforeEach(() => {
+    Model.getPathData = async () => ({ shapes: [] });
+});
+
+function connect() {
+    return ioClient(`http://localhost:${port}`, { forceNew: true, transports: ['websocket'] });
+}
+
+test('rejects a well-formed but unknown route code before any upstream fetch', async () => {
+    let pathCalled = false;
+    Model.getPathData = async () => { pathCalled = true; return { shapes: [] }; };
+
+    const client = connect();
+    try {
+        const ack = await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'unknown');
+        assert.equal(ack.ok, false);
+        assert.match(ack.error, /unknown route code/);
+        assert.equal(pathCalled, false);
+    } finally {
+        client.disconnect();
+    }
+});
+
+test('accepts a known route code', async () => {
+    const client = connect();
+    try {
+        const ack = await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'known');
+        assert.deepEqual(ack, { ok: true });
+    } finally {
+        client.disconnect();
+    }
+});
+
+test('enforces the per-socket subscription cap', async () => {
+    // isKnownRoute only allows 'known', so use a validator-bypassing server is
+    // not needed: cap is checked before isKnownRoute. Spin a dedicated server
+    // that treats every code as known to isolate the cap behaviour.
+    const srv = http.createServer();
+    const sio = new Server(srv);
+    const ctl = setupSocket(sio, {
+        pollIntervalMs: 60000,
+        isKnownRoute: async () => true,
+        maxRoutesPerSocket: 2,
+        subscribeRateLimit: null,
+    });
+    await new Promise((r) => srv.listen(0, r));
+    const p = srv.address().port;
+    const client = ioClient(`http://localhost:${p}`, { forceNew: true, transports: ['websocket'] });
+    try {
+        assert.equal((await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'a')).ok, true);
+        assert.equal((await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'b')).ok, true);
+        const third = await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'c');
+        assert.equal(third.ok, false);
+        assert.match(third.error, /subscription limit/);
+    } finally {
+        client.disconnect();
+        ctl.stop();
+        sio.close();
+        srv.close();
+    }
+});
+
+test('rate-limits subscribe spam from a single socket', async () => {
+    const srv = http.createServer();
+    const sio = new Server(srv);
+    const ctl = setupSocket(sio, {
+        pollIntervalMs: 60000,
+        isKnownRoute: async () => true,
+        maxRoutesPerSocket: 100,
+        subscribeRateLimit: { points: 2, windowMs: 60000 },
+    });
+    await new Promise((r) => srv.listen(0, r));
+    const p = srv.address().port;
+    const client = ioClient(`http://localhost:${p}`, { forceNew: true, transports: ['websocket'] });
+    try {
+        assert.equal((await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'r1')).ok, true);
+        assert.equal((await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'r2')).ok, true);
+        const third = await client.emitWithAck(Events.ROUTE_SUBSCRIBE, 'r3');
+        assert.equal(third.ok, false);
+        assert.match(third.error, /rate limited/);
+    } finally {
+        client.disconnect();
+        ctl.stop();
+        sio.close();
+        srv.close();
+    }
+});


### PR DESCRIPTION
Batch 2 of the 10-agent audit: the security/hardening findings deferred from #37. Verified against the code; tests cover the new guards.

## Socket DoS surface
- **Route-code validation** (`socket/index.js`, new `services/routeList.js`): a subscribe is now rejected unless the code is in the live route list, before any upstream fetch. `routeList` is a single shared TTL cache used by both the HTTP routes and the socket layer (so a cold cache hits upstream once).
- **Per-socket cap + rate limit**: max 50 active subscriptions per socket, and a sliding-window limit of 30 `route:subscribe` events / 10s per socket. Both injectable for tests.
- **Register-after-success**: the subscription is recorded and the room joined only after the path fetch succeeds, so a failed subscribe never leaves an active polled subscription.
- **Socket.IO CORS** (`app.js`): connections restricted to known origins (prod URL / localhost, override via `ALLOWED_ORIGINS`) so other sites can't open a socket cross-origin.

## Fan-out
- Vehicle updates now broadcast via Socket.IO **rooms** (`io.to(routeCode).emit(...)`) instead of a per-socket loop: encoded once, fanned out by Socket.IO. Removes the per-poll `O(routes x clients)` subscriber rebuild.

## Headers / XSS
- **helmet** added: frame protection, `nosniff`, referrer-policy, HSTS, `x-powered-by` removed. **CSP is intentionally deferred** - a policy strict enough to help must be tuned for the Google Maps JS API and verified in a real browser with a Maps key, which the referrer-restricted key blocks locally. Tracked as a follow-up.
- **InfoWindow XSS sink fixed** (`src/events.js`): the popup body is built with DOM + `textContent`, so upstream/client-supplied route and vehicle values can no longer inject markup.

## Resilience
- **Graceful shutdown** (`bin/www`): on SIGTERM/SIGINT, stop the poll loop, close io + server, force-exit after 10s. Render no longer hard-drops live sockets on every deploy.
- **Crash safety net**: `unhandledRejection` / `uncaughtException` handlers turn a stray error into a logged line + clean restart instead of silent downtime.

## Tests
New `test/socketSecurity.test.js` (unknown-route reject before fetch, per-socket cap, rate limit), registry `count`/`has`, and the existing socket integration test updated to inject `isKnownRoute`. **46 pass, 0 fail** (was 41). Build green; helmet headers and `/healthz` verified on a live boot; SIGTERM shutdown exercised.

## Verified header output (live boot)
```
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
referrer-policy: no-referrer
strict-transport-security: max-age=31536000; includeSubDomains
x-powered-by: (removed)
```

## Still deferred (batch 3)
- Enforcing Google-Maps-compatible CSP (needs in-browser verification with a key).
- UX/a11y: mobile-menu open/closed states, keyboard-accessible route checkboxes.
- Docs/repo: CONTRIBUTING/SECURITY/issue templates, demo.webp shrink, Dependabot, AdvancedMarkerElement migration.
