### PR TITLE
chore: a11y, frontend cleanups and public-repo health (audit batch 3)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report something that is broken or behaving unexpectedly
+title: "[bug] "
+labels: bug
+---
+
+## Description
+
+A clear description of what the bug is.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened (include console/server errors if any).
+
+## Environment
+
+- Browser / OS:
+- URL (live site or localhost):
+- Route(s) involved, if relevant:
+
+## Screenshots
+
+If applicable, add screenshots to help explain the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[feature] "
+labels: enhancement
+---
+
+## Problem
+
+What problem would this feature solve? What is the use case?
+
+## Proposed solution
+
+What you would like to see happen.
+
+## Alternatives considered
+
+Any alternative approaches you thought about.
+
+## Additional context
+
+Anything else (mockups, links, related issues).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Changes
+
+<!-- Bullet list of the notable changes. -->
+
+-
+
+## Testing
+
+<!-- How did you verify this? -->
+
+- [ ] `npm test` passes
+- [ ] `npm run build` passes
+- [ ] Added/updated tests where relevant
+- [ ] Manually verified in the browser (if UI/map behavior changed)
+
+## Related issues
+
+<!-- e.g. Closes #123 -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+      production-dependencies:
+        dependency-type: production
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our pledge
+
+We as contributors and maintainers pledge to make participation in this project
+a harassment-free experience for everyone, regardless of age, body size,
+disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing viewpoints and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the project and community.
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, or derogatory comments.
+- Publishing others' private information without permission.
+- Other conduct which could reasonably be considered inappropriate.
+
+## Enforcement
+
+Instances of abusive or unacceptable behavior may be reported to the maintainer
+via the repository's **Security** tab (private report) or by opening a regular
+issue for non-sensitive matters. All complaints will be reviewed and
+investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Thanks for your interest in improving the Lviv Transit Tracker.
+
+## Getting started
+
+```bash
+git clone https://github.com/tegos/lviv-transit-tracker.git
+cd lviv-transit-tracker
+npm install
+cp .env.example .env   # then set GOOGLE_MAPS_KEY
+```
+
+See the [README](README.md) for the full setup and environment-variable table.
+
+## Development workflow
+
+1. Fork the repo and create a feature branch with a descriptive name:
+   `git checkout -b feat/my-feature` (or `fix/...`, `chore/...`, `docs/...`).
+2. Make your change and add or update tests where it makes sense.
+3. Run the checks below locally.
+4. Push the branch and open a pull request against `main`.
+
+## Running checks
+
+```bash
+npm test               # unit + socket integration (offline)
+npm run test:coverage  # same, with coverage
+INTEGRATION=1 npm test # also hits the live api.lad.lviv.ua
+npm run build          # production Vite bundle (also runs in CI)
+npm run test:e2e       # Playwright browser smoke tests
+```
+
+CI runs the build, the test suite on Node 20/22/24, and `npm audit`. Please make
+sure `npm test` and `npm run build` pass before opening a PR.
+
+## Code style
+
+- Match the surrounding file's style (see `.editorconfig`).
+- Keep changes focused; one logical change per PR is easiest to review.
+- Frontend code lives in `src/` (vanilla ES modules, bundled by Vite). The
+  server is plain Express + Socket.IO. No frameworks beyond what is already here.
+
+## Reporting bugs and requesting features
+
+Use the issue templates. For anything security-related, follow
+[SECURITY.md](SECURITY.md) instead of opening a public issue.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Real-time public transit tracker for Lviv, Ukraine. Select bus routes on a Googl
 
 ## History
 
-Built in 2017 against the SimpleRIDE API provided by the Lviv transit authority. That API went offline in July 2018 and stayed dead for years. In 2026 the project was modernized (Node 24, Express 5, Socket.IO 4) and migrated to [api.lad.lviv.ua](https://github.com/vbhjckfd/timetable-api-node) - an open, live JSON REST API for Lviv public transit. Live bus data works again.
+Built in 2017 against the SimpleRIDE API provided by the Lviv transit authority. That API went offline in July 2018 and stayed dead for years. In 2026 the project was modernized (Node 20+, Express 5, Socket.IO 4) and migrated to [api.lad.lviv.ua](https://github.com/vbhjckfd/timetable-api-node) - an open, live JSON REST API for Lviv public transit. Live bus data works again.
 
 ## How it works
 
@@ -85,9 +85,16 @@ npm run test:e2e      # Playwright browser smoke tests
 
 ## Contributing
 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, the local checks to run, and
+the branch/PR workflow. In short:
+
 1. Fork the repo and create a feature branch (`git checkout -b feat/my-feature`)
 2. Make your changes and add tests where relevant
-3. Push the branch and open a pull request
+3. Run `npm test` and `npm run build`
+4. Push the branch and open a pull request
+
+Security issues: please follow [SECURITY.md](SECURITY.md) rather than opening a
+public issue. By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -95,4 +102,4 @@ MIT - see [LICENSE](LICENSE) for details.
 
 ## Author
 
-[Ivan Mykhavko](https://github.com/Tegos)
+[Ivan Mykhavko](https://github.com/tegos)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported versions
+
+This is a small single-deployment project; only the latest `main` is supported.
+Fixes are applied to `main` and redeployed.
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to the repository's **Security** tab.
+2. Click **Report a vulnerability**.
+3. Describe the issue, affected component, and steps to reproduce.
+
+You can expect an initial response within a few days. Once a fix is released,
+the report will be disclosed with credit to the reporter (unless you prefer
+otherwise).
+
+## Scope notes
+
+- The Google Maps API key is necessarily exposed to the browser; it is protected
+  by HTTP-referrer and API restrictions in Google Cloud, not by secrecy.
+- The server proxies a public upstream API (`api.lad.lviv.ua`); reports about
+  that upstream should go to its maintainers.

--- a/config/index.js
+++ b/config/index.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').config({ quiet: true });
 
 const parsedPollInterval = parseInt(process.env.POLL_INTERVAL_MS);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "compression": "^1.8.0",
         "debug": "^4.4.3",
-        "dotenv": "^16.5.0",
+        "dotenv": "^17.4.2",
         "ejs": "^6.0.1",
         "express": "^5.2.1",
         "helmet": "^8.2.0",
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "description": "Real-time Lviv public transit tracker - bus positions on Google Maps via Socket.IO and the api.lad.lviv.ua REST API",
   "keywords": [
     "lviv",
+    "ukraine",
     "transit",
+    "public-transport",
     "realtime",
     "socket.io",
     "express",
+    "vite",
+    "ejs",
     "google-maps",
     "bus-tracker"
   ],
@@ -26,12 +30,13 @@
     "build": "vite build",
     "dev": "vite build --watch",
     "test": "NODE_ENV=test node --test test/*.test.js",
+    "test:coverage": "NODE_ENV=test node --test --experimental-test-coverage test/*.test.js",
     "test:e2e": "playwright test"
   },
   "dependencies": {
     "compression": "^1.8.0",
     "debug": "^4.4.3",
-    "dotenv": "^16.5.0",
+    "dotenv": "^17.4.2",
     "ejs": "^6.0.1",
     "express": "^5.2.1",
     "helmet": "^8.2.0",

--- a/public/css/checkbox.css
+++ b/public/css/checkbox.css
@@ -1,9 +1,27 @@
+/* Visually hidden but still focusable and in the accessibility tree, so the
+   route checkboxes remain operable by keyboard and screen reader (display:none
+   removed them from both). The custom .check box is the visible control. */
 input[type="checkbox"] {
-    display: none;
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
 }
 
 input[type="checkbox"] ~ label {
     color: #f2f2f2;
+}
+
+/* Keyboard focus indicator on the custom box. */
+input[type="checkbox"]:focus-visible ~ label .check {
+    outline: 2px solid #8ab4f8;
+    outline-offset: 2px;
 }
 
 input[type="checkbox"] ~ label .check {

--- a/public/css/mobile.css
+++ b/public/css/mobile.css
@@ -14,6 +14,13 @@
         width: 240px;
     }
 
+    /* Comfortable touch targets for route rows (>= 44px recommended). */
+    #route_stops div {
+        height: auto;
+        min-height: 44px;
+        line-height: 44px;
+    }
+
     .navbar-toggle {
         display: block;
     }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -190,6 +190,23 @@ body.app-page {
     to { transform: rotate(360deg); }
 }
 
+/* Respect users who ask for less motion. */
+@media (prefers-reduced-motion: reduce) {
+    .route-row.loading > label::before {
+        animation-duration: 1.5s;
+    }
+    * {
+        scroll-behavior: auto;
+    }
+}
+
+/* Empty result message for the route search filter. */
+.route-empty {
+    padding: 12px;
+    color: #b6bbc0;
+    font-style: italic;
+}
+
 /* Route search filter */
 #route-search {
     box-sizing: border-box;

--- a/src/main.js
+++ b/src/main.js
@@ -20,10 +20,6 @@ window.initMap = function () {
         disableDefaultUI: true,
     });
     mapUtil = new MapUtil(map);
-
-    document.querySelectorAll('.clear-marker').forEach((el) => {
-        el.addEventListener('click', () => mapUtil.deleteMarkers());
-    });
 };
 
 function loadGoogleMaps(key) {
@@ -64,14 +60,31 @@ function clearLoading(routeCode) {
 // Client-side filter of the route sidebar by name or code.
 function wireRouteSearch() {
     const search = document.getElementById('route-search');
-    if (!search) return;
+    const list = document.getElementById('route_stops');
+    if (!search || !list) return;
+
+    let emptyEl = null;
+    const showEmpty = (visible) => {
+        if (!emptyEl) {
+            emptyEl = document.createElement('div');
+            emptyEl.className = 'route-empty';
+            emptyEl.textContent = 'Маршрутів не знайдено';
+            list.append(emptyEl);
+        }
+        emptyEl.style.display = visible === 0 ? '' : 'none';
+    };
+
     search.addEventListener('input', () => {
         const q = search.value.trim().toLowerCase();
-        document.querySelectorAll('#route_stops .route-row').forEach((row) => {
+        let visible = 0;
+        list.querySelectorAll('.route-row').forEach((row) => {
             const name = (row.dataset.name || '').toLowerCase();
             const code = (row.dataset.code || '').toLowerCase();
-            row.style.display = (!q || name.includes(q) || code.includes(q)) ? '' : 'none';
+            const show = !q || name.includes(q) || code.includes(q);
+            row.style.display = show ? '' : 'none';
+            if (show) visible++;
         });
+        showEmpty(visible);
     });
 }
 

--- a/src/map.js
+++ b/src/map.js
@@ -12,11 +12,6 @@ const MARKER_PATH = 'M39.652,16.446C39.652,7.363,32.289,0,23.206,0C14.124,0,6.76
 export function createMap(el, options) {
     const map = new google.maps.Map(el, { zoom: 5, ...options });
 
-    window.addEventListener('resize', () => {
-        const center = map.getCenter();
-        map.setCenter(center);
-    });
-
     if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition((position) => {
             map.setCenter(new google.maps.LatLng(position.coords.latitude, position.coords.longitude));

--- a/src/markerAnimate.js
+++ b/src/markerAnimate.js
@@ -20,14 +20,19 @@ export function installMarkerAnimate() {
         }
 
         const animateStep = (marker, startTime) => {
+            // Marker removed from the map mid-flight (e.g. route unsubscribed):
+            // stop animating instead of churning frames on a detached marker.
+            if (!marker.getMap()) return;
+
             const elapsed = performance.now() - startTime;
             const ratio = elapsed / duration; // 0 - 1 (linear easing)
 
             if (ratio < 1) {
-                marker.setPosition(new google.maps.LatLng(
-                    marker.AT_startPosition_lat + (newPosition_lat - marker.AT_startPosition_lat) * ratio,
-                    marker.AT_startPosition_lng + (newPosition_lng - marker.AT_startPosition_lng) * ratio,
-                ));
+                // LatLngLiteral avoids allocating a new LatLng object each frame.
+                marker.setPosition({
+                    lat: marker.AT_startPosition_lat + (newPosition_lat - marker.AT_startPosition_lat) * ratio,
+                    lng: marker.AT_startPosition_lng + (newPosition_lng - marker.AT_startPosition_lng) * ratio,
+                });
                 marker.AT_animationHandler = requestAnimationFrame(() => animateStep(marker, startTime));
             } else {
                 marker.setPosition(newPosition);

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,6 +1,6 @@
 <nav class="navbar">
     <div class="navbar-inner">
-        <a class="navbar-brand clear-marker" href="/">Транспорт Львова Live</a>
+        <a class="navbar-brand" href="/">Транспорт Львова Live</a>
         <button type="button" class="navbar-toggle" aria-label="Меню" aria-controls="navbar" aria-expanded="false">
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>


### PR DESCRIPTION
Batch 3 of the 10-agent audit: the accessibility, frontend-cleanup, and public-repo-health findings. Lower-risk than the earlier batches; the visual-heavy reworks are intentionally deferred (see bottom).

## Accessibility / UX
- **Keyboard-operable route checkboxes** (`public/css/checkbox.css`): the route checkboxes used `display:none`, which removed them from the tab order and the accessibility tree, so the app's primary interaction was impossible by keyboard or screen reader. Replaced with a visually-hidden-but-focusable pattern and a focus ring on the custom box. The `:checked` styling is unchanged.
- **prefers-reduced-motion** (`public/css/style.css`): slow the loading spinner for users who request reduced motion.
- **Empty search state** (`src/main.js`): show "Маршрутів не знайдено" when the route filter matches nothing, instead of a silently blank sidebar.
- **Touch targets** (`public/css/mobile.css`): route rows bumped to a >=44px target on mobile.

## Frontend cleanups
- Removed the no-op `window` resize listener in `createMap` (Google Maps already preserves center on resize).
- `markerAnimate`: bail out when a marker is removed mid-animation (stop churning frames on a detached marker), and pass a `LatLngLiteral` per frame instead of allocating a new `google.maps.LatLng`.
- Removed the dead `.clear-marker` click handler - the navbar brand is an `<a href="/">` that reloads the page anyway, so `deleteMarkers()` never had any effect - and dropped the misleading class.

## Tooling / deps
- `dotenv` 16 -> 17, with `{ quiet: true }` to silence the new load banner.
- Added a `test:coverage` script (`node --experimental-test-coverage`).

## Public-repo health
- Added `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, a PR template, and bug/feature issue templates.
- Added `.editorconfig` and `.github/dependabot.yml` (weekly npm + github-actions, grouped).
- README/metadata: aligned the History Node version with the supported range, fixed the author handle case (`Tegos` -> `tegos`), and added `ukraine`/`public-transport`/`vite`/`ejs` keywords.

## Verification
`npm test` 46 pass / 2 skipped, `npm run build` green, `npm run test:coverage` runs. The CSS/interaction a11y changes (checkbox focus pattern, touch targets, empty state) are standard and low-risk but were not browser-verified here (referrer-restricted Maps key blocks a local run) - worth a quick eyeball on the deploy preview.

## Deferred (would need in-browser verification or are larger)
- Mobile-menu open/closed states + a persistent toggle (the swipe-off-screen UX).
- Enforcing Google-Maps-compatible CSP.
- `google.maps.Marker` -> `AdvancedMarkerElement` migration.
- Shrinking the 5.3MB README `demo.webp`.
