### PR TITLE
chore: group dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,12 @@ updates:
         dependency-type: development
       production-dependencies:
         dependency-type: production
+      dev-security:
+        applies-to: security-updates
+        dependency-type: development
+      production-security:
+        applies-to: security-updates
+        dependency-type: production
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Security updates ignored the existing groups (groups default to `applies-to: version-updates`), so each alert opened its own PR - e.g. #50.

Adds `dev-security` and `production-security` groups with `applies-to: security-updates`.