### PR TITLE
fix(deps): bump nanoid to 3.3.18 in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,9 +1501,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes the last open Dependabot alert: GHSA-2v37-7h3g-55p8 (high) - nanoid custom generators can loop indefinitely when size is zero.

Transitive: vite -> postcss -> nanoid. Lockfile-only change via `npm audit fix`. `npm audit` now reports 0 vulnerabilities; test suite passes (46 pass, 2 skipped).